### PR TITLE
fix(#3): update contract status on ingestion completion

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,4 +1,5 @@
 """Database connection and helper functions using asyncpg."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -74,6 +75,28 @@ async def update_ingestion_job(
         status=status,
         progress=progress,
     )
+
+
+# ---------------------------------------------------------------------------
+# Contract helpers
+# ---------------------------------------------------------------------------
+
+
+async def update_contract_status(
+    pool: asyncpg.Pool,
+    contract_id: str,
+    status: str,
+) -> None:
+    """Update contracts.status column."""
+    now = datetime.now(timezone.utc)
+    async with pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE contracts SET status = $1, updated_at = $2 WHERE id = $3",
+            status,
+            now,
+            contract_id,
+        )
+    log.info("contract status updated", contract_id=contract_id, status=status)
 
 
 # ---------------------------------------------------------------------------

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -19,6 +19,7 @@ Processing pipeline:
     9. Job status → completed, progress 100%
    10. On failure → job status failed, store error message
 """
+
 from __future__ import annotations
 
 import os
@@ -163,6 +164,7 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
         await update_ingestion_job(
             pool, job_id, status="completed", progress=100, current_step="완료"
         )
+        await update_contract_status(pool, contract_id, "ready")
         log.info("ingestion completed", job_id=job_id, contract_id=contract_id)
 
     finally:
@@ -204,6 +206,7 @@ def make_handler(
                     progress=0,
                     error_message=str(exc),
                 )
+                await update_contract_status(pool, contract_id, "failed")
             except Exception:
                 log.exception("failed to update job status to failed", job_id=job_id)
             raise  # re-raise so aio-pika nacks → DLQ


### PR DESCRIPTION
## 변경사항
- `db.py`: `update_contract_status()` 함수 추가
- `ingestion.py`: 완료 시 `contracts.status = 'ready'`, 실패 시 `'failed'` 업데이트

## QA 결과
- ingestion 완료 후 contract.status가 'ready'로 변경됨 (signsafe-ai 배포 후 확인 필요)
- 타입 불일치 해소: web types/index.ts의 ContractStatus 'ready'와 일치

Closes #3