### PR TITLE
fix(#5): ingestion.py에서 update_contract_status import 누락 수정

### DIFF
--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -19,6 +19,7 @@ Processing pipeline:
     9. Job status → completed, progress 100%
    10. On failure → job status failed, store error message
 """
+
 from __future__ import annotations
 
 import os
@@ -35,6 +36,7 @@ import structlog
 
 from app.db import (
     insert_clauses_batch,
+    update_contract_status,
     update_ingestion_job,
 )
 from app.services import embeddings as emb_svc
@@ -163,6 +165,7 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
         await update_ingestion_job(
             pool, job_id, status="completed", progress=100, current_step="완료"
         )
+        await update_contract_status(pool, contract_id, "ready")
         log.info("ingestion completed", job_id=job_id, contract_id=contract_id)
 
     finally:
@@ -204,6 +207,7 @@ def make_handler(
                     progress=0,
                     error_message=str(exc),
                 )
+                await update_contract_status(pool, contract_id, "failed")
             except Exception:
                 log.exception("failed to update job status to failed", job_id=job_id)
             raise  # re-raise so aio-pika nacks → DLQ


### PR DESCRIPTION
## 변경사항
- app.db에서 update_contract_status import 추가
- ingestion 완료 시 contracts.status를 ready로 업데이트
- ingestion 실패 시 contracts.status를 failed로 업데이트

## 수정된 버그
ingestion 워커가 완료/실패해도 contract의 status가 uploaded에서 변경되지 않아
프론트엔드에서 계약 상태가 항상 uploaded로 표시되는 문제 해결.
NameError: name 'update_contract_status' is not defined 런타임 에러 수정.

## QA 결과
- [x] python3 -c "import ast; ast.parse(open('app/workers/ingestion.py').read())" 성공
- [x] app.db imports: ['insert_clauses_batch', 'update_contract_status', 'update_ingestion_job'] 확인

Closes #5