### PR TITLE
fix(#9): analysis worker 부분 실패 시 전체 분석 실패 방지

### DIFF
--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -17,6 +17,7 @@ Processing pipeline:
     4. Analysis status completed
     5. On failure → status failed
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -111,7 +112,9 @@ async def _analyze_single_clause(
                 "clause_result_id": clause_result_id,
                 "rationale": llm_result.rationale,
                 "citations": citations,
-                "recommended_actions": _build_recommended_actions(llm_result.issue_types),
+                "recommended_actions": _build_recommended_actions(
+                    llm_result.issue_types
+                ),
                 "top_k": 3,
                 "filter_params": {},
             },
@@ -164,12 +167,33 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
     log.info("loaded clauses", count=len(clauses))
 
     # Step 3 — parallel analysis with bounded concurrency.
+    # Use return_exceptions=True so a single clause failure does not abort others.
     semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
     tasks = [
         _analyze_single_clause(pool, analysis_id, clause, semaphore)
         for clause in clauses
     ]
-    await asyncio.gather(*tasks)
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    # Log per-clause failures but do not propagate; partial results are acceptable.
+    failed_count = 0
+    for clause, result in zip(clauses, results):
+        if isinstance(result, BaseException):
+            failed_count += 1
+            log.error(
+                "clause analysis failed",
+                clause_id=clause["id"],
+                analysis_id=analysis_id,
+                error=str(result),
+            )
+
+    if failed_count:
+        log.warning(
+            "analysis completed with clause failures",
+            analysis_id=analysis_id,
+            failed=failed_count,
+            total=len(clauses),
+        )
 
     # Step 4 — mark completed.
     await update_risk_analysis(


### PR DESCRIPTION
## 변경사항
- `asyncio.gather(*tasks, return_exceptions=True)` 사용
- 개별 clause 실패는 오류 로그로만 기록
- 실패한 clause 수/전체 수 경고 로그 추가
- 나머지 성공한 clause는 분석 완료로 처리

## 문제 설명
기존에는 단일 clause 분석 실패 시 전체 gather가 예외를 전파하여:
1. 다른 태스크들이 계속 실행되어 부분적으로 DB에 저장됨
2. 분석 상태는 `failed`로 마킹됨
3. 결과: `status=failed`인 분석에 일부 clause_results가 남아 데이터 불일치

## QA 결과
- [x] ruff check 통과

Closes #9