### PR TITLE
fix(#11): add content field to Qdrant payload for citation snippets

### DIFF
--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -151,6 +151,7 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
                     "clause_id": c["id"],
                     "contract_id": contract_id,
                     "label": c.get("label"),
+                    "content": c["content"][:500],  # truncated for RAG snippet display
                     "org_id": None,  # org_id populated later via contract lookup
                     "created_at": now_ts.isoformat(),
                     "created_at_ts": now_ts.timestamp(),


### PR DESCRIPTION
## 변경사항
- ingestion.py: Qdrant payload에 content 필드 추가 (최대 500자 truncation)
- analysis.py의 citation snippet 조회가 이제 실제 조항 내용을 반환함

## QA 결과
- [x] py_compile pass
- [x] analysis.py의 `s.get("payload", {}).get("content", "")` 가 이제 실제 content를 반환

Closes #11