### PR TITLE
fix(#13): align citation dict fields with frontend Citation TypeScript interface

### DIFF
--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -72,13 +72,17 @@ async def _analyze_single_clause(
         )
 
         # Build citations from similar clauses.
+        # Field names must match the frontend Citation TypeScript interface:
+        # id, type, title, snippet, whyRelevant, source?, score?
         citations = [
             {
-                "clause_id": s.get("clause_id"),
-                "contract_id": s.get("contract_id"),
-                "label": s.get("label"),
-                "score": s.get("score"),
+                "id": s.get("clause_id") or "",
+                "type": "clause",
+                "title": s.get("label") or "Similar clause",
                 "snippet": s.get("payload", {}).get("content", "")[:200],
+                "whyRelevant": "",
+                "source": s.get("contract_id"),
+                "score": s.get("score"),
             }
             for s in similar
         ]


### PR DESCRIPTION
## 변경사항
- analysis.py: citation 딕셔너리 필드를 프론트엔드 Citation 인터페이스와 일치시킴
  - id: clause_id
  - type: 'clause'
  - title: label 또는 'Similar clause' 기본값
  - snippet: payload.content[:200]
  - whyRelevant: '' (기본값)
  - source: contract_id
  - score: score

## QA 결과
- [x] py_compile pass
- [x] CitationCard의 title, type, snippet이 정상 렌더링됨

Closes #13