### PR TITLE
fix(#19): ANTHROPIC_API_KEY/OPENAI_API_KEY 미설정 시 즉시 실패

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 
 import structlog
 
@@ -9,7 +10,23 @@ from app.queue import ANALYSIS_QUEUE, INGESTION_QUEUE, connect_queue, consume
 log = structlog.get_logger()
 
 
+def _validate_config() -> None:
+    """Fail fast if required API keys are missing."""
+    missing: list[str] = []
+    if not settings.anthropic_api_key:
+        missing.append("ANTHROPIC_API_KEY")
+    if not settings.openai_api_key:
+        missing.append("OPENAI_API_KEY")
+    if missing:
+        log.error(
+            "required API keys are not set — cannot start worker",
+            missing=missing,
+        )
+        sys.exit(1)
+
+
 async def main() -> None:
+    _validate_config()
     log.info("signsafe-ai worker starting", env=settings.env)
 
     db = await connect_db()


### PR DESCRIPTION
## 변경사항
- main.py에 _validate_config() 추가
- ANTHROPIC_API_KEY 또는 OPENAI_API_KEY가 빈 문자열이면 sys.exit(1)로 즉시 종료
- 누락된 키 목록을 로그에 출력

## QA 결과
- ruff check app/ 통과
- syntax OK

Closes #19