### PR TITLE
fix(#21): analysis worker Qdrant 컬렉션 존재 확인 후 RAG 검색

### DIFF
--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -156,6 +156,10 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
     # Step 1 — mark running.
     await update_risk_analysis(pool, analysis_id, status="running")
 
+    # Ensure Qdrant collection exists before running RAG searches.
+    # This handles the case where Qdrant restarts and the collection is gone.
+    await rag_svc.ensure_collection()
+
     # Step 2 — load clauses.
     clauses = await get_clauses_for_contract(pool, contract_id)
     if not clauses:


### PR DESCRIPTION
## 변경사항
- analysis worker _process()에 await rag_svc.ensure_collection() 추가
- Qdrant 재시작 후 컬렉션 없을 때 search_similar_clauses() 오류 방지

## QA 결과
- ruff check 통과
- syntax OK

Closes #21