### PR TITLE
fix(#23): populate org_id in Qdrant and scope RAG search per organization

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -82,6 +82,37 @@ async def update_ingestion_job(
 # ---------------------------------------------------------------------------
 
 
+async def get_org_id_for_contract(
+    pool: asyncpg.Pool,
+    contract_id: str,
+) -> str | None:
+    """Return the organization_id for a contract, or None if not found."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            "SELECT organization_id FROM contracts WHERE id = $1",
+            contract_id,
+        )
+    return row["organization_id"] if row else None
+
+
+async def get_org_id_for_analysis(
+    pool: asyncpg.Pool,
+    analysis_id: str,
+) -> str | None:
+    """Return the organization_id for a risk analysis via contract join."""
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            """
+            SELECT c.organization_id
+            FROM risk_analyses ra
+            JOIN contracts c ON c.id = ra.contract_id
+            WHERE ra.id = $1
+            """,
+            analysis_id,
+        )
+    return row["organization_id"] if row else None
+
+
 async def update_contract_status(
     pool: asyncpg.Pool,
     contract_id: str,

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -30,6 +30,7 @@ import structlog
 
 from app.db import (
     get_clauses_for_contract,
+    get_org_id_for_analysis,
     insert_clause_result,
     insert_evidence_set,
     update_risk_analysis,
@@ -52,6 +53,7 @@ async def _analyze_single_clause(
     analysis_id: str,
     clause: asyncpg.Record,
     semaphore: asyncio.Semaphore,
+    org_id: str | None = None,
 ) -> None:
     """Run LLM + RAG for one clause and persist results."""
     async with semaphore:
@@ -65,10 +67,13 @@ async def _analyze_single_clause(
         # LLM analysis.
         llm_result = await analyze_clause(clause_text)
 
-        # RAG: find similar clauses.
+        # RAG: find similar clauses scoped to the same organization.
+        # Passing org_id ensures we only surface evidence from the org's own
+        # historical contracts, preventing cross-tenant data leakage.
         similar = await rag_svc.search_similar_clauses(
             query_text=clause_text,
             top_k=3,
+            org_id=org_id,
         )
 
         # Build citations from similar clauses.
@@ -174,11 +179,19 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 
     log.info("loaded clauses", count=len(clauses))
 
+    # Fetch org_id to scope RAG search to this organization only.
+    org_id = await get_org_id_for_analysis(pool, analysis_id)
+    if org_id is None:
+        log.warning(
+            "org_id not found for analysis — RAG will search across all orgs",
+            analysis_id=analysis_id,
+        )
+
     # Step 3 — parallel analysis with bounded concurrency.
     # Use return_exceptions=True so a single clause failure does not abort others.
     semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
     tasks = [
-        _analyze_single_clause(pool, analysis_id, clause, semaphore)
+        _analyze_single_clause(pool, analysis_id, clause, semaphore, org_id=org_id)
         for clause in clauses
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -35,6 +35,7 @@ import boto3
 import structlog
 
 from app.db import (
+    get_org_id_for_contract,
     insert_clauses_batch,
     update_contract_status,
     update_ingestion_job,
@@ -139,6 +140,14 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
         # Ensure Qdrant collection exists.
         await rag_svc.ensure_collection()
 
+        # Look up the organization ID so Qdrant payloads can be filtered per org.
+        org_id = await get_org_id_for_contract(pool, contract_id)
+        if org_id is None:
+            log.warning(
+                "org_id not found for contract — Qdrant points will have null org_id",
+                contract_id=contract_id,
+            )
+
         # Generate embeddings in batches.
         texts = [c["content"] for c in clause_dicts]
         vectors = await emb_svc.embed(texts)
@@ -152,7 +161,7 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
                     "contract_id": contract_id,
                     "label": c.get("label"),
                     "content": c["content"][:500],  # truncated for RAG snippet display
-                    "org_id": None,  # org_id populated later via contract lookup
+                    "org_id": org_id,
                     "created_at": now_ts.isoformat(),
                     "created_at_ts": now_ts.timestamp(),
                 },


### PR DESCRIPTION
## 변경사항
- app/db.py: get_org_id_for_contract(), get_org_id_for_analysis() 헬퍼 추가
- app/workers/ingestion.py: Qdrant 포인트 저장 시 실제 org_id 채움 (기존: None 하드코딩)
- app/workers/analysis.py: analysis_id로 org_id 조회 후 search_similar_clauses(org_id=...) 호출로 RAG 검색 범위를 동일 조직으로 한정

## 배경
이전에는 org_id=None으로 저장되어 RAG 검색 시 필터가 없었고, 다른 조직의 계약서 조항이 증거로 노출될 수 있는 크로스-테넌트 데이터 유출 위험이 있었습니다.

## QA 결과
- ruff check 통과

Closes #23