### PR TITLE
fix(#25): per-clause LLM 호출에 타임아웃 및 retry 로직 추가

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -2,19 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import re
 from dataclasses import dataclass
 from typing import Any
 
 import structlog
-from anthropic import AsyncAnthropic
+from anthropic import APIStatusError, AsyncAnthropic
+from tenacity import (
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from app.config import settings
 
 log = structlog.get_logger()
 
 MODEL = "claude-3-5-sonnet-20241022"
+
+# Timeout in seconds for a single LLM API call.
+_LLM_CALL_TIMEOUT = 60.0
 
 _client: AsyncAnthropic | None = None
 
@@ -24,6 +34,13 @@ def _get_client() -> AsyncAnthropic:
     if _client is None:
         _client = AsyncAnthropic(api_key=settings.anthropic_api_key)
     return _client
+
+
+def _is_retryable(exc: BaseException) -> bool:
+    """Return True for Anthropic 429 (rate limit) and 503 (overloaded) errors."""
+    if isinstance(exc, APIStatusError):
+        return exc.status_code in (429, 503)
+    return False
 
 
 _ANALYSIS_PROMPT_TEMPLATE = """계약서 조항을 분석하여 리스크를 평가해주세요.
@@ -81,18 +98,46 @@ def _normalize_risk_level(value: str) -> str:
     return mapping.get(value.strip(), "MEDIUM")
 
 
+@retry(
+    retry=retry_if_exception(_is_retryable),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    stop=stop_after_attempt(3),
+    reraise=True,
+)
+async def _call_llm(client: AsyncAnthropic, prompt: str) -> str:
+    """Call Claude API with timeout and retry on 429/503."""
+    message = await asyncio.wait_for(
+        client.messages.create(
+            model=MODEL,
+            max_tokens=1024,
+            messages=[{"role": "user", "content": prompt}],
+        ),
+        timeout=_LLM_CALL_TIMEOUT,
+    )
+    return message.content[0].text
+
+
 async def analyze_clause(clause_text: str) -> ClauseAnalysisResult:
     """Run LLM risk analysis on a single clause and return structured result."""
     client = _get_client()
     prompt = _ANALYSIS_PROMPT_TEMPLATE.format(clause_text=clause_text)
 
-    message = await client.messages.create(
-        model=MODEL,
-        max_tokens=1024,
-        messages=[{"role": "user", "content": prompt}],
-    )
-
-    raw_text = message.content[0].text
+    try:
+        raw_text = await _call_llm(client, prompt)
+    except TimeoutError:
+        log.error(
+            "LLM call timed out",
+            timeout=_LLM_CALL_TIMEOUT,
+            clause_preview=clause_text[:100],
+        )
+        raise
+    except APIStatusError as exc:
+        log.error(
+            "LLM API error after retries",
+            status_code=exc.status_code,
+            clause_preview=clause_text[:100],
+        )
+        raise
 
     try:
         data = _extract_json(raw_text)

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -41,6 +41,8 @@ from app.services.llm import MODEL, analyze_clause
 log = structlog.get_logger()
 
 _MAX_CONCURRENCY = 5
+# Total timeout per clause: LLM (60 s) + RAG + DB writes.
+_CLAUSE_TIMEOUT = 120.0
 
 
 def _new_id() -> str:
@@ -64,8 +66,22 @@ async def _analyze_single_clause(
 
         log.info("analyzing clause", clause_id=clause_id, label=label)
 
-        # LLM analysis.
-        llm_result = await analyze_clause(clause_text)
+        # LLM analysis with per-clause total timeout.
+        # analyze_clause() already applies a 60 s call-level timeout; this outer
+        # guard covers the full pipeline (LLM + RAG + DB) to prevent a semaphore
+        # slot from being occupied indefinitely.
+        try:
+            llm_result = await asyncio.wait_for(
+                analyze_clause(clause_text), timeout=_CLAUSE_TIMEOUT
+            )
+        except TimeoutError:
+            log.error(
+                "clause analysis timed out",
+                clause_id=clause_id,
+                analysis_id=analysis_id,
+                timeout=_CLAUSE_TIMEOUT,
+            )
+            raise
 
         # RAG: find similar clauses scoped to the same organization.
         # Passing org_id ensures we only surface evidence from the org's own

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "boto3>=1.34",
   "pydantic-settings>=2.0",
   "structlog>=24.0",
+  "tenacity>=8.2",
 ]
 
 [build-system]


### PR DESCRIPTION
## 변경사항
- `llm.py`: `asyncio.wait_for(timeout=60s)`로 Claude API call hang 방지
- `llm.py`: tenacity `@retry`로 429/503 에러 exponential backoff 재시도 (최대 3회, 2–30s 대기)
- `analysis.py`: `_analyze_single_clause`에 `asyncio.wait_for(timeout=120s)` 추가 (LLM+RAG+DB 전체 파이프라인 guard)
- `pyproject.toml`: `tenacity>=8.2` 의존성 추가

## QA 결과
- ruff check: All checks passed

Closes #25