### PR TITLE
fix(#29): DLQ consumer 추가 — 실패 메시지 모니터링

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,7 +6,15 @@ import structlog
 
 from app.config import settings
 from app.db import connect_db
-from app.queue import ANALYSIS_QUEUE, INGESTION_QUEUE, connect_queue, consume
+from app.queue import (
+    ANALYSIS_DLQ,
+    ANALYSIS_QUEUE,
+    INGESTION_DLQ,
+    INGESTION_QUEUE,
+    connect_queue,
+    consume,
+    consume_dlq,
+)
 
 log = structlog.get_logger()
 
@@ -52,7 +60,7 @@ async def main() -> None:
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, _request_shutdown, sig)
 
-    # Run consumers until a shutdown signal is received.
+    # Run main consumers and DLQ monitors until a shutdown signal is received.
     # asyncio.gather is cancelled when shutdown_event fires so that
     # in-flight aio-pika message handlers finish naturally (aio-pika
     # drains pending acks before closing the channel).
@@ -60,6 +68,8 @@ async def main() -> None:
         asyncio.gather(
             consume(queue_conn, INGESTION_QUEUE, ingestion_handler),
             consume(queue_conn, ANALYSIS_QUEUE, analysis_handler),
+            consume_dlq(queue_conn, INGESTION_DLQ),
+            consume_dlq(queue_conn, ANALYSIS_DLQ),
         )
     )
 

--- a/app/queue.py
+++ b/app/queue.py
@@ -1,4 +1,5 @@
 """Message queue connection and helpers using aio-pika (RabbitMQ)."""
+
 from __future__ import annotations
 
 import json
@@ -15,6 +16,9 @@ log = structlog.get_logger()
 # Queue names — must match signsafe-api declarations
 INGESTION_QUEUE = "ingestion.jobs"
 ANALYSIS_QUEUE = "analysis.jobs"
+
+INGESTION_DLQ = f"{INGESTION_QUEUE}.dlq"
+ANALYSIS_DLQ = f"{ANALYSIS_QUEUE}.dlq"
 
 
 async def connect_queue() -> aio_pika.abc.AbstractRobustConnection:
@@ -43,6 +47,40 @@ async def _declare_queue_with_dlq(
         },
     )
     return queue
+
+
+async def consume_dlq(
+    connection: aio_pika.abc.AbstractRobustConnection,
+    dlq_name: str,
+) -> None:
+    """Consume messages from a DLQ and log each one as an error.
+
+    DLQ messages represent processing failures. This consumer ensures they are
+    never silently accumulated — every entry is logged so operators can triage.
+    """
+    channel = await connection.channel()
+    await channel.set_qos(prefetch_count=1)
+
+    # DLQ is a plain durable queue (no dead-letter on the DLQ itself).
+    queue = await channel.declare_queue(dlq_name, durable=True)
+
+    log.info("starting DLQ consumer", queue=dlq_name)
+
+    async with queue.iterator() as messages:
+        async for message in messages:
+            async with message.process(requeue=False):
+                try:
+                    body_str = message.body.decode(errors="replace")
+                    headers = dict(message.headers or {})
+                    log.error(
+                        "DLQ message received — manual intervention required",
+                        queue=dlq_name,
+                        body=body_str[:500],
+                        headers=headers,
+                        message_id=message.message_id,
+                    )
+                except Exception:
+                    log.exception("failed to log DLQ message", queue=dlq_name)
 
 
 async def consume(


### PR DESCRIPTION
## 변경사항
- `queue.py`: `consume_dlq()` 함수 추가 — DLQ 메시지를 `log.error()`로 기록 (body, headers, message_id 포함)
- `queue.py`: `INGESTION_DLQ`, `ANALYSIS_DLQ` 상수 export
- `main.py`: ingestion/analysis DLQ consumer를 `asyncio.gather`에 포함

## QA 결과
- ruff check: All checks passed

Closes #29