### PR TITLE
fix(#31): offload blocking S3 download and PDF parsing to thread pool

### DIFF
--- a/app/services/parser.py
+++ b/app/services/parser.py
@@ -223,8 +223,12 @@ def _parse_docx(data: bytes) -> list[Clause]:
 # ---------------------------------------------------------------------------
 
 
-async def parse(file_path: Path) -> list[Clause]:
-    """Parse a PDF or DOCX file and return a list of Clause objects."""
+def parse_sync(file_path: Path) -> list[Clause]:
+    """Parse a PDF or DOCX file synchronously and return a list of Clause objects.
+
+    This is the canonical implementation. Use this function directly when running
+    in a thread (e.g. via asyncio.run_in_executor) to avoid blocking the event loop.
+    """
     data = file_path.read_bytes()
     suffix = file_path.suffix.lower()
 
@@ -239,3 +243,16 @@ async def parse(file_path: Path) -> list[Clause]:
 
     log.info("parsing complete", clause_count=len(clauses))
     return clauses
+
+
+async def parse(file_path: Path) -> list[Clause]:
+    """Async shim — kept for backward compatibility.
+
+    Prefer calling ``parse_sync`` via ``loop.run_in_executor`` so that the
+    synchronous C library (PyMuPDF) does not block the event loop.
+    """
+    import asyncio
+    import functools
+
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, functools.partial(parse_sync, file_path))

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -22,6 +22,8 @@ Processing pipeline:
 
 from __future__ import annotations
 
+import asyncio
+import functools
 import os
 import pathlib
 import tempfile
@@ -34,6 +36,7 @@ import asyncpg
 import boto3
 import structlog
 
+from app.config import settings
 from app.db import (
     get_org_id_for_contract,
     insert_clauses_batch,
@@ -43,7 +46,6 @@ from app.db import (
 from app.services import embeddings as emb_svc
 from app.services import parser as parser_svc
 from app.services import rag as rag_svc
-from app.config import settings
 
 log = structlog.get_logger()
 
@@ -87,11 +89,19 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
         tmp_path = pathlib.Path(tmp.name)
 
     try:
-        _download_file(file_path, tmp_path)
+        # Offload blocking network I/O to a thread so the event loop
+        # (shared with the analysis worker) is not blocked during download.
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, functools.partial(_download_file, file_path, tmp_path)
+        )
         log.info("file downloaded", path=str(tmp_path), size=tmp_path.stat().st_size)
 
-        # Step 2 — parse
-        clauses = await parser_svc.parse(tmp_path)
+        # Step 2 — parse (CPU-bound + sync C library; offload to thread pool
+        # to avoid blocking the event loop shared with the analysis worker)
+        clauses = await loop.run_in_executor(
+            None, functools.partial(parser_svc.parse_sync, tmp_path)
+        )
         log.info("parsing complete", clause_count=len(clauses))
 
         # Step 3 → chunking


### PR DESCRIPTION
## 변경사항
- `app/workers/ingestion.py`: `_download_file` 및 `parser_svc.parse_sync` 호출을 `asyncio.run_in_executor`로 래핑하여 이벤트 루프 블로킹 제거
- `app/services/parser.py`: `parse_sync()` 동기 함수 추가 (정식 구현체); 기존 `async parse()`는 하위 호환을 위해 `run_in_executor` 위임 shim으로 변환

## 문제 설명
boto3 S3 다운로드와 PyMuPDF 파싱은 동기 블로킹 연산이며, 대용량 계약서(50MB PDF)의 경우 5~30초 이상 소요될 수 있습니다.
ingestion 워커와 analysis 워커가 동일한 asyncio 이벤트 루프를 공유하므로, 블로킹 발생 시 분석 메시지 소비, DLQ 처리, SIGTERM 핸들링이 모두 지연됩니다.

## QA 결과
- `ruff check app/workers/ingestion.py app/services/parser.py` → All checks passed

Closes #31