### PR TITLE
feat(#35): 재시도 가능 오류 분류 및 지수 백오프 재시도 로직

### DIFF
--- a/app/errors.py
+++ b/app/errors.py
@@ -1,0 +1,30 @@
+"""Structured error hierarchy for signsafe-ai workers.
+
+Errors are split into two categories:
+
+RetryableError
+    Transient failures that are safe to retry (network blips, rate limits,
+    temporary upstream unavailability).  The queue consumer will attempt up
+    to MAX_RETRIES retries with exponential back-off before giving up and
+    routing the message to the DLQ.
+
+PermanentError
+    Unrecoverable failures where retrying will never help (malformed message,
+    missing required fields, unsupported file type, schema mismatch).  The
+    queue consumer will ack the message immediately (no DLQ) after marking
+    the job/analysis as failed so the problem is visible in the database.
+"""
+
+from __future__ import annotations
+
+
+class SignSafeWorkerError(Exception):
+    """Base class for all worker errors."""
+
+
+class RetryableError(SignSafeWorkerError):
+    """A transient error that may succeed on retry."""
+
+
+class PermanentError(SignSafeWorkerError):
+    """An unrecoverable error; retrying will not help."""

--- a/app/queue.py
+++ b/app/queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Awaitable, Callable
 from typing import Any
@@ -10,6 +11,7 @@ import aio_pika
 import structlog
 
 from app.config import settings
+from app.errors import PermanentError, RetryableError
 
 log = structlog.get_logger()
 
@@ -19,6 +21,11 @@ ANALYSIS_QUEUE = "analysis.jobs"
 
 INGESTION_DLQ = f"{INGESTION_QUEUE}.dlq"
 ANALYSIS_DLQ = f"{ANALYSIS_QUEUE}.dlq"
+
+# Retry configuration for RetryableError
+_MAX_RETRIES = 3
+_RETRY_BASE_DELAY = 2.0  # seconds
+_RETRY_MAX_DELAY = 30.0  # seconds
 
 
 async def connect_queue() -> aio_pika.abc.AbstractRobustConnection:
@@ -90,8 +97,13 @@ async def consume(
 ) -> None:
     """Consume messages from queue_name, calling handler for each message.
 
-    On handler success the message is acked.
-    On any exception the message is nacked (requeue=False) so it goes to DLQ.
+    Error handling strategy:
+    - PermanentError: ack the message (no retry, no DLQ). The handler is
+      responsible for recording failure in the DB before raising.
+    - RetryableError: retry up to _MAX_RETRIES times with exponential back-off.
+      If all retries are exhausted, nack → DLQ.
+    - Any other Exception: treated as RetryableError (unknown errors may be
+      transient) — same retry/DLQ path.
     """
     channel = await connection.channel()
     await channel.set_qos(prefetch_count=1)
@@ -101,10 +113,64 @@ async def consume(
 
     async with queue.iterator() as messages:
         async for message in messages:
-            async with message.process(requeue=False):
+            # Use manual ack/nack so we can control DLQ routing precisely.
+            try:
+                body = json.loads(message.body)
+            except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                log.error(
+                    "unparseable message — acking to prevent DLQ loop",
+                    queue=queue_name,
+                    error=str(exc),
+                )
+                await message.ack()
+                continue
+
+            last_exc: BaseException | None = None
+            for attempt in range(1, _MAX_RETRIES + 1):
                 try:
-                    body = json.loads(message.body)
                     await handler(body)
-                except Exception:
-                    log.exception("message processing failed", queue=queue_name)
-                    raise  # aio-pika nacks and routes to DLQ
+                    last_exc = None
+                    break  # success
+                except PermanentError as exc:
+                    log.error(
+                        "permanent error — acking message without DLQ",
+                        queue=queue_name,
+                        attempt=attempt,
+                        error=str(exc),
+                    )
+                    last_exc = exc
+                    break  # do not retry permanent errors
+                except (RetryableError, Exception) as exc:
+                    last_exc = exc
+                    if attempt < _MAX_RETRIES:
+                        delay = min(
+                            _RETRY_BASE_DELAY * (2 ** (attempt - 1)),
+                            _RETRY_MAX_DELAY,
+                        )
+                        log.warning(
+                            "retryable error — will retry",
+                            queue=queue_name,
+                            attempt=attempt,
+                            max_retries=_MAX_RETRIES,
+                            delay=delay,
+                            error=str(exc),
+                        )
+                        await asyncio.sleep(delay)
+                    else:
+                        log.error(
+                            "all retries exhausted — routing to DLQ",
+                            queue=queue_name,
+                            max_retries=_MAX_RETRIES,
+                            error=str(exc),
+                        )
+
+            if last_exc is None:
+                # Success
+                await message.ack()
+            elif isinstance(last_exc, PermanentError):
+                # Permanent failure: ack so it does NOT go to DLQ.
+                # The handler has already written the failure to the DB.
+                await message.ack()
+            else:
+                # Retryable failure exhausted all attempts: nack → DLQ.
+                await message.nack(requeue=False)

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -16,6 +16,12 @@ Processing pipeline:
        d. Save evidence_set to DB
     4. Analysis status completed
     5. On failure → status failed
+
+Error classification:
+    PermanentError — missing required fields, DB schema issues. Message is
+        acked immediately; no DLQ routing.
+    RetryableError — DB connection loss, LLM 429/503, timeout. Consumer retries
+        up to _MAX_RETRIES times with exponential back-off before routing to DLQ.
 """
 
 from __future__ import annotations
@@ -27,6 +33,7 @@ from typing import Any
 
 import asyncpg
 import structlog
+from anthropic import APIStatusError
 
 from app.db import (
     get_clauses_for_contract,
@@ -35,6 +42,7 @@ from app.db import (
     insert_evidence_set,
     update_risk_analysis,
 )
+from app.errors import PermanentError, RetryableError
 from app.services import rag as rag_svc
 from app.services.llm import MODEL, analyze_clause
 
@@ -48,6 +56,36 @@ _CLAUSE_TIMEOUT = 120.0
 def _new_id() -> str:
     """Generate a 26-char alphanumeric ID (similar to ULID format)."""
     return str(uuid.uuid4()).replace("-", "")[:26]
+
+
+def _classify_exception(exc: BaseException) -> type[RetryableError | PermanentError]:
+    """Map an arbitrary exception to a retryable vs permanent category.
+
+    Rules:
+    - Anthropic 429 (rate limit) / 503 (overloaded) → retryable
+    - asyncpg connection errors → retryable
+    - TimeoutError / asyncio.TimeoutError → retryable (may recover)
+    - All other Anthropic API errors → permanent (bad request, auth)
+    - KeyError / TypeError / ValueError (malformed data) → permanent
+    """
+    if isinstance(exc, APIStatusError):
+        if exc.status_code in (429, 503):
+            return RetryableError
+        return PermanentError
+
+    if isinstance(
+        exc, (asyncpg.PostgresConnectionError, asyncpg.TooManyConnectionsError)
+    ):
+        return RetryableError
+
+    if isinstance(exc, (TimeoutError, asyncio.TimeoutError)):
+        return RetryableError
+
+    if isinstance(exc, (KeyError, TypeError, ValueError)):
+        return PermanentError
+
+    # Default: treat as retryable (unknown errors may be transient)
+    return RetryableError
 
 
 async def _analyze_single_clause(
@@ -97,8 +135,6 @@ async def _analyze_single_clause(
         )
 
         # Build citations from similar clauses.
-        # Field names must match the frontend Citation TypeScript interface:
-        # id, type, title, snippet, whyRelevant, source?, score?
         citations = [
             {
                 "id": s.get("clause_id") or "",
@@ -173,20 +209,31 @@ def _build_recommended_actions(issue_types: list[str]) -> list[str]:
 
 
 async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
-    contract_id: str = msg["contractId"]
-    analysis_id: str = msg["analysisId"]
+    # Validate required fields — raise PermanentError if missing
+    try:
+        contract_id: str = msg["contractId"]
+        analysis_id: str = msg["analysisId"]
+    except KeyError as exc:
+        raise PermanentError(f"Missing required message field: {exc}") from exc
 
     log.info("analysis started", analysis_id=analysis_id, contract_id=contract_id)
 
     # Step 1 — mark running.
-    await update_risk_analysis(pool, analysis_id, status="running")
+    try:
+        await update_risk_analysis(pool, analysis_id, status="running")
+    except asyncpg.PostgresConnectionError as exc:
+        raise RetryableError(f"DB connection error on status update: {exc}") from exc
 
     # Ensure Qdrant collection exists before running RAG searches.
     # This handles the case where Qdrant restarts and the collection is gone.
     await rag_svc.ensure_collection()
 
     # Step 2 — load clauses.
-    clauses = await get_clauses_for_contract(pool, contract_id)
+    try:
+        clauses = await get_clauses_for_contract(pool, contract_id)
+    except asyncpg.PostgresConnectionError as exc:
+        raise RetryableError(f"DB connection error loading clauses: {exc}") from exc
+
     if not clauses:
         log.warning("no clauses found for contract", contract_id=contract_id)
         await update_risk_analysis(
@@ -216,27 +263,40 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 
-    # Log per-clause failures but do not propagate; partial results are acceptable.
-    failed_count = 0
+    # Categorise per-clause failures.
+    failed_retryable = 0
+    failed_permanent = 0
     for clause, result in zip(clauses, results):
         if isinstance(result, BaseException):
-            failed_count += 1
+            category = _classify_exception(result)
+            if category is RetryableError:
+                failed_retryable += 1
+            else:
+                failed_permanent += 1
             log.error(
                 "clause analysis failed",
                 clause_id=clause["id"],
                 analysis_id=analysis_id,
+                error_type=category.__name__,
                 error=str(result),
             )
 
+    failed_count = failed_retryable + failed_permanent
     if failed_count:
         log.warning(
             "analysis completed with clause failures",
             analysis_id=analysis_id,
-            failed=failed_count,
+            failed_retryable=failed_retryable,
+            failed_permanent=failed_permanent,
             total=len(clauses),
         )
 
-    # Step 4 — mark completed.
+    # If ALL clauses failed with retryable errors (none permanent), propagate
+    # as RetryableError so the consumer can retry the entire analysis job.
+    if failed_retryable == len(clauses) and failed_permanent == 0:
+        raise RetryableError(f"All {len(clauses)} clauses failed with retryable errors")
+
+    # Step 4 — mark completed (partial success is still completed).
     await update_risk_analysis(
         pool,
         analysis_id,
@@ -257,14 +317,11 @@ def make_handler(
 
     RETRIEVE_EVIDENCE messages are acknowledged and ignored here because the
     actual retrieval logic (re-running RAG) is not yet implemented as a background
-    step — evidence is already populated during the initial analysis pass. Silently
-    dropping the message prevents the queue from being poisoned with unhandled types.
+    step — evidence is already populated during the initial analysis pass.
     """
 
     async def handler(msg: dict[str, Any]) -> None:
-        # Route by message type. RETRIEVE_EVIDENCE messages are sent to this
-        # queue by evidenceSvc.RetrieveEvidence and must not be processed as
-        # analysis jobs (they lack contractId/analysisId fields).
+        # Route by message type.
         msg_type = msg.get("type")
         if msg_type == "RETRIEVE_EVIDENCE":
             log.info(
@@ -277,9 +334,9 @@ def make_handler(
         contract_id = msg.get("contractId", "unknown")
         try:
             await _process(pool, msg)
-        except Exception as exc:
-            log.exception(
-                "analysis failed",
+        except PermanentError as exc:
+            log.error(
+                "permanent analysis failure — marking failed, acking message (no DLQ)",
                 analysis_id=analysis_id,
                 contract_id=contract_id,
                 error=str(exc),
@@ -296,6 +353,26 @@ def make_handler(
                     "failed to update analysis status to failed",
                     analysis_id=analysis_id,
                 )
-            raise  # re-raise so aio-pika nacks → DLQ
+            raise  # re-raise PermanentError; queue.consume acks without DLQ
+        except (RetryableError, Exception) as exc:
+            log.error(
+                "retryable analysis failure — will retry or route to DLQ",
+                analysis_id=analysis_id,
+                contract_id=contract_id,
+                error=str(exc),
+            )
+            try:
+                await update_risk_analysis(
+                    pool,
+                    analysis_id,
+                    status="failed",
+                    error_message=str(exc),
+                )
+            except Exception:
+                log.exception(
+                    "failed to update analysis status to failed",
+                    analysis_id=analysis_id,
+                )
+            raise  # re-raise; queue.consume retries or nacks → DLQ
 
     return handler

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -18,6 +18,12 @@ Processing pipeline:
     8. Generate embeddings → upsert to Qdrant
     9. Job status → completed, progress 100%
    10. On failure → job status failed, store error message
+
+Error classification:
+    PermanentError — missing required fields, unsupported file type, PDF parse
+        errors. Message is acked; no DLQ routing.
+    RetryableError — S3 download failures, DB connection errors, Qdrant
+        unavailability. Consumer retries with exponential back-off.
 """
 
 from __future__ import annotations
@@ -34,6 +40,7 @@ from typing import Any
 import asyncpg
 import boto3
 import structlog
+from botocore.exceptions import BotoCoreError, ClientError
 
 from app.config import settings
 from app.db import (
@@ -42,6 +49,7 @@ from app.db import (
     update_contract_status,
     update_ingestion_job,
 )
+from app.errors import PermanentError, RetryableError
 from app.services import embeddings as emb_svc
 from app.services import parser as parser_svc
 from app.services import rag as rag_svc
@@ -86,16 +94,32 @@ async def _download_and_parse(
     tmp_path: pathlib.Path,
 ) -> list[Any]:
     """Download file from S3 and parse it into raw clauses."""
-    await loop.run_in_executor(
-        None, functools.partial(_download_file, file_path, tmp_path)
-    )
+    try:
+        await loop.run_in_executor(
+            None, functools.partial(_download_file, file_path, tmp_path)
+        )
+    except ClientError as exc:
+        error_code = exc.response.get("Error", {}).get("Code", "")
+        if error_code in ("NoSuchKey", "404", "AccessDenied", "403"):
+            raise PermanentError(
+                f"S3 object not accessible: {file_path} ({error_code})"
+            ) from exc
+        raise RetryableError(f"S3 download failed (retryable): {exc}") from exc
+    except BotoCoreError as exc:
+        raise RetryableError(f"S3 connection error: {exc}") from exc
+
     log.info("file downloaded", path=str(tmp_path), size=tmp_path.stat().st_size)
 
     # CPU-bound + sync C library; offload to thread pool to avoid blocking
     # the event loop shared with the analysis worker.
-    clauses = await loop.run_in_executor(
-        None, functools.partial(parser_svc.parse_sync, tmp_path)
-    )
+    try:
+        clauses = await loop.run_in_executor(
+            None, functools.partial(parser_svc.parse_sync, tmp_path)
+        )
+    except Exception as exc:
+        # Parser errors are permanent — the file content won't change on retry.
+        raise PermanentError(f"Document parse error: {exc}") from exc
+
     log.info("parsing complete", clause_count=len(clauses))
     return clauses
 
@@ -154,16 +178,23 @@ def _build_qdrant_points(
 
 
 async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
-    contract_id: str = msg["contractId"]
-    job_id: str = msg["jobId"]
-    file_path: str = msg["filePath"]
+    # Validate required fields — raise PermanentError if missing
+    try:
+        contract_id: str = msg["contractId"]
+        job_id: str = msg["jobId"]
+        file_path: str = msg["filePath"]
+    except KeyError as exc:
+        raise PermanentError(f"Missing required message field: {exc}") from exc
 
     log.info("ingestion started", job_id=job_id, contract_id=contract_id)
 
     # Step 1 → parsing
-    await update_ingestion_job(
-        pool, job_id, status="parsing", progress=0, current_step="파일 다운로드 중"
-    )
+    try:
+        await update_ingestion_job(
+            pool, job_id, status="parsing", progress=0, current_step="파일 다운로드 중"
+        )
+    except asyncpg.PostgresConnectionError as exc:
+        raise RetryableError(f"DB connection error: {exc}") from exc
 
     suffix = _guess_suffix(file_path)
     with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
@@ -185,7 +216,13 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
         now_ts = datetime.now(timezone.utc)
         clause_dicts = _build_clause_dicts(clauses, now_ts)
 
-        await insert_clauses_batch(pool, contract_id, clause_dicts)
+        try:
+            await insert_clauses_batch(pool, contract_id, clause_dicts)
+        except asyncpg.PostgresConnectionError as exc:
+            raise RetryableError(
+                f"DB connection error inserting clauses: {exc}"
+            ) from exc
+
         log.info("clauses saved to DB", count=len(clause_dicts))
 
         # Step 3 → indexing
@@ -199,7 +236,11 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 
         await rag_svc.ensure_collection()
 
-        org_id = await get_org_id_for_contract(pool, contract_id)
+        try:
+            org_id = await get_org_id_for_contract(pool, contract_id)
+        except asyncpg.PostgresConnectionError as exc:
+            raise RetryableError(f"DB connection error fetching org_id: {exc}") from exc
+
         if org_id is None:
             log.warning(
                 "org_id not found for contract — Qdrant points will have null org_id",
@@ -235,9 +276,9 @@ def make_handler(
         contract_id = msg.get("contractId", "unknown")
         try:
             await _process(pool, msg)
-        except Exception as exc:
-            log.exception(
-                "ingestion failed",
+        except PermanentError as exc:
+            log.error(
+                "permanent ingestion failure — marking failed, acking message (no DLQ)",
                 job_id=job_id,
                 contract_id=contract_id,
                 error=str(exc),
@@ -253,6 +294,25 @@ def make_handler(
                 await update_contract_status(pool, contract_id, "failed")
             except Exception:
                 log.exception("failed to update job status to failed", job_id=job_id)
-            raise  # re-raise so aio-pika nacks → DLQ
+            raise  # re-raise PermanentError; queue.consume acks without DLQ
+        except (RetryableError, Exception) as exc:
+            log.error(
+                "retryable ingestion failure — will retry or route to DLQ",
+                job_id=job_id,
+                contract_id=contract_id,
+                error=str(exc),
+            )
+            try:
+                await update_ingestion_job(
+                    pool,
+                    job_id,
+                    status="failed",
+                    progress=0,
+                    error_message=str(exc),
+                )
+                await update_contract_status(pool, contract_id, "failed")
+            except Exception:
+                log.exception("failed to update job status to failed", job_id=job_id)
+            raise  # re-raise; queue.consume retries or nacks → DLQ
 
     return handler


### PR DESCRIPTION
## 변경사항

- `app/errors.py` (신규): `RetryableError` / `PermanentError` 예외 계층
- `app/queue.py`: `consume()` 오류 분류 기반 재시도 로직
  - **PermanentError**: 즉시 ack (DLQ 미전달)
  - **RetryableError**: 지수 백오프(2s base, 30s max) 후 최대 3회 재시도
  - 재시도 소진 시 nack → DLQ
  - 파싱 불가 메시지 → ack (DLQ 루프 방지)
- `app/workers/analysis.py`:
  - `_classify_exception()`: 429/503 → retryable, 기타 API 오류 → permanent
  - asyncpg 연결 오류 → retryable, TimeoutError → retryable
  - KeyError/TypeError → permanent
  - 전체 clause가 retryable 오류면 RetryableError 전파 (job 재시도 가능)
- `app/workers/ingestion.py`:
  - S3 NoSuchKey/AccessDenied → permanent (재시도 불필요)
  - S3 네트워크 오류 → retryable
  - PDF 파싱 오류 → permanent (파일 내용은 재시도로 안 바뀜)
  - DB 연결 오류 → retryable

## QA 결과

- PermanentError 발생 시 DLQ에 쌓이지 않음
- RetryableError는 백오프 후 재시도, 소진 시 DLQ
- 기존 동작(성공 케이스) 변경 없음

Closes #35