### PR TITLE
feat(#37): LLM 분석 결과에 confidence score (0~1) 추가

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -130,3 +130,23 @@
 **DLQ 큐 이름**:
 - `ingestion.jobs.dlq`
 - `analysis.jobs.dlq`
+
+---
+
+## ADR-007: LLM 응답 confidence score 추가
+
+**날짜**: 2026-04-01
+
+**결정**: LLM 프롬프트에 `confidence: 0.0~1.0` 필드를 요청하고, `ClauseAnalysisResult`에 포함하여 DB에 저장한다.
+
+**이유**:
+- risk_level만으로는 판단의 확실성을 알 수 없음
+- UI에서 "낮은 신뢰도" 조항을 다르게 표시하거나 사용자 검토 유도 가능
+- 프롬프트 수정만으로 추가 가능하며 LLM 호출 횟수 증가 없음
+
+**설계**:
+- 파싱 실패 또는 범위 초과 시 `_normalize_confidence()`가 0.5로 클램핑
+- DB 컬럼: `clause_results.confidence FLOAT NOT NULL DEFAULT 0.5` (migration 000006)
+- 이전에 저장된 행은 DEFAULT 0.5로 초기화됨
+
+**영향**: signsafe-api 마이그레이션 필요 (000006 추가, 완료)

--- a/app/db.py
+++ b/app/db.py
@@ -281,8 +281,8 @@ async def insert_clause_result(
     """Insert a clause_result row and return its id.
 
     result dict fields:
-        id, analysis_id, clause_id, risk_level, issue_type,
-        summary, highlight_x, highlight_y, highlight_width,
+        id, analysis_id, clause_id, risk_level, confidence (float, default 0.5),
+        issue_type, summary, highlight_x, highlight_y, highlight_width,
         highlight_height, page_number
     """
     now = datetime.now(timezone.utc)
@@ -290,21 +290,22 @@ async def insert_clause_result(
         await conn.execute(
             """
             INSERT INTO clause_results (
-                id, analysis_id, clause_id, risk_level, issue_type,
+                id, analysis_id, clause_id, risk_level, confidence, issue_type,
                 summary, highlight_x, highlight_y,
                 highlight_width, highlight_height, page_number,
                 created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5,
-                $6, $7, $8,
-                $9, $10, $11,
-                $12, $12
+                $6, $7, $8, $9,
+                $10, $11, $12,
+                $13, $13
             )
             """,
             result["id"],
             result["analysis_id"],
             result["clause_id"],
             result["risk_level"],
+            float(result.get("confidence", 0.5)),
             result.get("issue_type"),
             result.get("summary"),
             result.get("highlight_x"),

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 import structlog
@@ -50,10 +50,16 @@ _ANALYSIS_PROMPT_TEMPLATE = """계약서 조항을 분석하여 리스크를 평
 다음 JSON 형식으로만 응답하세요:
 {{
   "risk_level": "HIGH|MEDIUM|LOW",
+  "confidence": 0.85,
   "issue_types": ["LIABILITY_LIMITATION", ...],
   "summary": "한국어 리스크 요약 (2-3문장)",
   "rationale": "판단 근거 상세 설명"
 }}
+
+confidence 필드 설명:
+- 0.0~1.0 사이의 숫자로, 위험도 판단에 대한 신뢰도를 나타냅니다.
+- 1.0에 가까울수록 명확하고 확실한 판단, 0.5에 가까울수록 해석이 불분명합니다.
+- 예시: 명확한 고위험 조항 → 0.95, 해석 여지가 있는 조항 → 0.65
 
 이슈 유형 목록:
 - LIABILITY_LIMITATION: 손해배상 제한
@@ -72,10 +78,11 @@ class ClauseAnalysisResult:
     """Result of LLM clause risk analysis."""
 
     risk_level: str  # HIGH | MEDIUM | LOW
+    confidence: float  # 0.0 ~ 1.0
     issue_types: list[str]
     summary: str
     rationale: str
-    raw: dict[str, Any]
+    raw: dict[str, Any] = field(default_factory=dict)
 
 
 def _extract_json(text: str) -> dict[str, Any]:
@@ -96,6 +103,15 @@ def _normalize_risk_level(value: str) -> str:
     # Fallback mapping for unexpected values.
     mapping = {"높음": "HIGH", "중간": "MEDIUM", "낮음": "LOW"}
     return mapping.get(value.strip(), "MEDIUM")
+
+
+def _normalize_confidence(value: Any) -> float:
+    """Clamp confidence to [0.0, 1.0]. Returns 0.5 on invalid input."""
+    try:
+        f = float(value)
+        return max(0.0, min(1.0, f))
+    except (TypeError, ValueError):
+        return 0.5
 
 
 @retry(
@@ -148,6 +164,7 @@ async def analyze_clause(clause_text: str) -> ClauseAnalysisResult:
         # Return safe defaults on parse failure.
         return ClauseAnalysisResult(
             risk_level="MEDIUM",
+            confidence=0.5,
             issue_types=[],
             summary="분석 결과를 파싱하지 못했습니다.",
             rationale=raw_text,
@@ -156,6 +173,7 @@ async def analyze_clause(clause_text: str) -> ClauseAnalysisResult:
 
     return ClauseAnalysisResult(
         risk_level=_normalize_risk_level(data.get("risk_level", "MEDIUM")),
+        confidence=_normalize_confidence(data.get("confidence", 0.5)),
         issue_types=data.get("issue_types", []),
         summary=data.get("summary", ""),
         rationale=data.get("rationale", ""),

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -10,9 +10,9 @@ Processing pipeline:
     1. Receive message → Analysis status running
     2. Load clauses from DB
     3. Parallel analysis (max 5 concurrent):
-       a. LLM analysis → risk_level, issue_types, summary, rationale
+       a. LLM analysis → risk_level, confidence, issue_types, summary, rationale
        b. RAG search → topK=3 similar clauses
-       c. Save clause_result to DB
+       c. Save clause_result to DB (including confidence)
        d. Save evidence_set to DB
     4. Analysis status completed
     5. On failure → status failed
@@ -148,7 +148,7 @@ async def _analyze_single_clause(
             for s in similar
         ]
 
-        # Persist clause_result.
+        # Persist clause_result (includes confidence score from LLM).
         clause_result_id = _new_id()
         await insert_clause_result(
             pool,
@@ -157,6 +157,7 @@ async def _analyze_single_clause(
                 "analysis_id": analysis_id,
                 "clause_id": clause_id,
                 "risk_level": llm_result.risk_level,
+                "confidence": llm_result.confidence,
                 "issue_type": (
                     llm_result.issue_types[0] if llm_result.issue_types else None
                 ),
@@ -189,6 +190,7 @@ async def _analyze_single_clause(
             "clause analysis saved",
             clause_id=clause_id,
             risk_level=llm_result.risk_level,
+            confidence=llm_result.confidence,
         )
 
 


### PR DESCRIPTION
## 변경사항

- `llm.py`: 프롬프트에 `confidence: 0.0~1.0` 필드 요청 추가 (판단 신뢰도)
- `ClauseAnalysisResult` 데이터클래스에 `confidence: float` 필드 추가
- `_normalize_confidence()`: 0~1 범위 클램핑, 파싱 실패 시 0.5 반환
- `db.py`: `insert_clause_result` SQL에 `confidence` 컬럼 포함 ($5 파라미터)
- `workers/analysis.py`: `insert_clause_result` 호출 시 `llm_result.confidence` 전달
- 로그에 `confidence` 값 추가 출력 (`clause analysis saved`)

## 의존성
- signsafe-api PR #119에서 `migrations/000006` 마이그레이션 적용 후 이 워커 배포 필요
  - `clause_results.confidence FLOAT NOT NULL DEFAULT 0.5` 컬럼 존재해야 함

## QA 결과
- Python 문법 검사 (ast.parse): PASS — llm.py, analysis.py, db.py 모두 통과
- 파싱 실패 시 기본값 0.5 적용 (기존 동작과 동일한 MEDIUM 기본값 패턴 유지)

Closes #37