### PR TITLE
fix(#40): update_risk_analysis_summary 컬럼 부재 시 graceful skip + 정리

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -150,3 +150,37 @@
 - 이전에 저장된 행은 DEFAULT 0.5로 초기화됨
 
 **영향**: signsafe-api 마이그레이션 필요 (000006 추가, 완료)
+
+---
+
+## ADR-008: update_risk_analysis_summary 컬럼 부재 시 graceful skip
+
+**날짜**: 2026-04-14
+
+**결정**: `update_risk_analysis_summary()`에서 `asyncpg.exceptions.UndefinedColumnError` 발생 시 경고 로그만 남기고 skip한다. 에러를 전파하지 않으므로 분석 완료 흐름에 영향 없다.
+
+**배경**:
+- `risk_analyses` 테이블에 `document_summary`, `overall_risk`, `key_issues` 컬럼 추가는 signsafe-api 측 마이그레이션으로 처리
+- 마이그레이션 전까지 해당 컬럼이 없어 호출마다 DB 에러 발생
+- 기존 코드에서 `analysis.py`의 `try/except Exception`으로 잡혀 비치명적이었으나, 의도가 명확하지 않았음
+
+**구현**:
+- `db.py`의 `update_risk_analysis_summary` 내부에서 `UndefinedColumnError`를 직접 잡아 처리
+- 마이그레이션 완료 후 동일 코드가 자동으로 정상 동작 (코드 변경 불필요)
+
+**대안 검토**:
+- `analysis.py`의 `try/except` 유지: 의도가 불명확하고 모든 예외를 삼킴
+- 컬럼 존재 여부 사전 체크: 매 호출마다 `information_schema` 조회 → 오버헤드
+
+---
+
+## ADR-009: anthropic_api_key 설정 필드 제거
+
+**날짜**: 2026-04-14
+
+**결정**: `config.py`에서 `anthropic_api_key` 필드 제거
+
+**이유**:
+- ADR-003에서 LLM을 OpenAI gpt-4o로 전환하여 Anthropic SDK 미사용
+- 미사용 환경변수를 선언하면 운영자 혼란 유발
+- xquare Vault에서도 해당 키 주입 불필요

--- a/app/config.py
+++ b/app/config.py
@@ -16,7 +16,6 @@ class Settings(BaseSettings):
     s3_secret_key: str = ""
     s3_bucket: str = "contracts"
 
-    anthropic_api_key: str = ""
     openai_api_key: str = ""
     law_api_oc: str = ""
 

--- a/app/db.py
+++ b/app/db.py
@@ -331,22 +331,36 @@ async def update_risk_analysis_summary(
         ADD COLUMN document_summary TEXT,
         ADD COLUMN overall_risk VARCHAR(10),
         ADD COLUMN key_issues JSONB;
+
+    If the columns do not exist yet (migration pending), the call is silently
+    skipped and a warning is logged. Once the migration is applied, subsequent
+    calls will persist data automatically — no code change required.
     """
     now = datetime.now(timezone.utc)
-    async with pool.acquire() as conn:
-        await conn.execute(
-            """
-            UPDATE risk_analyses
-            SET document_summary = $1, overall_risk = $2,
-                key_issues = $3, updated_at = $4
-            WHERE id = $5
-            """,
-            document_summary,
-            overall_risk,
-            json.dumps(key_issues, ensure_ascii=False),
-            now,
-            analysis_id,
+    try:
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE risk_analyses
+                SET document_summary = $1, overall_risk = $2,
+                    key_issues = $3, updated_at = $4
+                WHERE id = $5
+                """,
+                document_summary,
+                overall_risk,
+                json.dumps(key_issues, ensure_ascii=False),
+                now,
+                analysis_id,
+            )
+    except asyncpg.exceptions.UndefinedColumnError:
+        # Columns are added by a pending migration on signsafe-api side.
+        # Skip gracefully so the analysis job still completes successfully.
+        log.warning(
+            "update_risk_analysis_summary skipped — columns not yet migrated "
+            "(document_summary / overall_risk / key_issues missing on risk_analyses)",
+            analysis_id=analysis_id,
         )
+        return
     log.info(
         "risk_analysis document summary updated",
         analysis_id=analysis_id,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ dependencies = [
   "aio-pika>=9.0",
   "asyncpg>=0.29",
   "qdrant-client>=1.7",
-  "anthropic>=0.25",
   "openai>=1.0",
   "pymupdf>=1.23",
   "python-docx>=1.1",


### PR DESCRIPTION
## 변경사항

- **db.py**: `update_risk_analysis_summary()`에서 `asyncpg.exceptions.UndefinedColumnError` 감지 시 경고 로그만 남기고 skip. `risk_analyses` 테이블에 `document_summary`/`overall_risk`/`key_issues` 컬럼이 없는 동안(마이그레이션 대기) 분석 완료 흐름을 방해하지 않음. 마이그레이션 완료 후 코드 변경 없이 자동으로 정상 동작
- **config.py**: 미사용 `anthropic_api_key` 필드 제거 (ADR-003에서 OpenAI gpt-4o로 전환 완료)
- **pyproject.toml**: 미사용 `anthropic>=0.25` 의존성 제거
- **DECISIONS.md**: ADR-008 (graceful skip 전략), ADR-009 (anthropic 제거) 추가

## QA 결과

- UndefinedColumnError graceful skip 로직 확인 PASS
- anthropic 의존성 완전 제거 확인 PASS
- 전체 Python 파일 syntax 검사 PASS

Closes #40