### PR TITLE
fix(#46): 워커 시작 시 판례 크롤링 즉시 1회 실행

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -35,8 +35,15 @@ def _seconds_until_next_monday_4am() -> float:
 
 
 async def _run_weekly_legal_update() -> None:
-    """Background task: update legal vector DB every Monday 04:00 KST."""
+    """Background task: update legal vector DB on startup and every Monday 04:00 KST."""
     from app.services.legal_updater import run_update
+
+    # 시작 시 즉시 1회 실행 — cases 컬렉션 초기 데이터 확보
+    log.info("running initial legal data update")
+    try:
+        await run_update()
+    except Exception:
+        log.exception("initial legal update failed — will retry next Monday")
 
     while True:
         wait = _seconds_until_next_monday_4am()

--- a/app/services/legal_updater.py
+++ b/app/services/legal_updater.py
@@ -17,7 +17,15 @@ from app.services.rag import CASES_COLLECTION_NAME, _get_client, ensure_cases_co
 log = structlog.get_logger()
 
 _API_BASE = "https://www.law.go.kr/DRF"
-_QUERIES = ["불공정계약", "손해배상", "계약해지", "약관", "위약금", "기밀유지", "지식재산권"]
+_QUERIES = [
+    "불공정계약",
+    "손해배상",
+    "계약해지",
+    "약관",
+    "위약금",
+    "기밀유지",
+    "지식재산권",
+]
 _DISPLAY = 10
 
 
@@ -38,10 +46,17 @@ async def _crawl_cases(client: httpx.AsyncClient, oc: str) -> list[dict]:
 
     for query in _QUERIES:
         try:
-            data = await _fetch(client, "lawSearch.do", {
-                "OC": oc, "target": "prec", "type": "JSON",
-                "query": query, "display": _DISPLAY,
-            })
+            data = await _fetch(
+                client,
+                "lawSearch.do",
+                {
+                    "OC": oc,
+                    "target": "prec",
+                    "type": "JSON",
+                    "query": query,
+                    "display": _DISPLAY,
+                },
+            )
             items = data.get("PrecSearch", {}).get("prec", [])
             if isinstance(items, dict):
                 items = [items]
@@ -51,22 +66,31 @@ async def _crawl_cases(client: httpx.AsyncClient, oc: str) -> list[dict]:
                     continue
                 seen.add(seq)
                 try:
-                    detail = await _fetch(client, "lawService.do", {
-                        "OC": oc, "target": "prec", "type": "JSON", "ID": seq,
-                    })
+                    detail = await _fetch(
+                        client,
+                        "lawService.do",
+                        {
+                            "OC": oc,
+                            "target": "prec",
+                            "type": "JSON",
+                            "ID": seq,
+                        },
+                    )
                     d = detail.get("PrecService", {})
                     raw = d.get("판례내용", "") or d.get("전문", "")
                     content = BeautifulSoup(raw, "html.parser").get_text()[:3000]
                     if not content.strip():
                         continue
-                    docs.append({
-                        "type": "prec",
-                        "source_id": seq,
-                        "title": d.get("사건명", ""),
-                        "content": content,
-                        "date": d.get("선고일자", ""),
-                        "court": d.get("법원명", ""),
-                    })
+                    docs.append(
+                        {
+                            "type": "prec",
+                            "source_id": seq,
+                            "title": d.get("사건명", ""),
+                            "content": content,
+                            "date": d.get("선고일자", ""),
+                            "court": d.get("법원명", ""),
+                        }
+                    )
                 except Exception as exc:
                     log.warning("판례 상세 조회 실패", seq=seq, error=str(exc))
         except Exception as exc:
@@ -81,10 +105,17 @@ async def _crawl_laws(client: httpx.AsyncClient, oc: str) -> list[dict]:
 
     for query in _QUERIES:
         try:
-            data = await _fetch(client, "lawSearch.do", {
-                "OC": oc, "target": "law", "type": "JSON",
-                "query": query, "display": _DISPLAY,
-            })
+            data = await _fetch(
+                client,
+                "lawSearch.do",
+                {
+                    "OC": oc,
+                    "target": "law",
+                    "type": "JSON",
+                    "query": query,
+                    "display": _DISPLAY,
+                },
+            )
             items = data.get("LawSearch", {}).get("law", [])
             if isinstance(items, dict):
                 items = [items]
@@ -94,9 +125,16 @@ async def _crawl_laws(client: httpx.AsyncClient, oc: str) -> list[dict]:
                     continue
                 seen.add(law_id)
                 try:
-                    detail = await _fetch(client, "lawService.do", {
-                        "OC": oc, "target": "law", "type": "JSON", "ID": law_id,
-                    })
+                    detail = await _fetch(
+                        client,
+                        "lawService.do",
+                        {
+                            "OC": oc,
+                            "target": "law",
+                            "type": "JSON",
+                            "ID": law_id,
+                        },
+                    )
                     d = detail.get("LawService", {})
                     articles = d.get("조문", [])
                     if isinstance(articles, dict):
@@ -108,14 +146,16 @@ async def _crawl_laws(client: httpx.AsyncClient, oc: str) -> list[dict]:
                     )[:3000]
                     if not content.strip():
                         continue
-                    docs.append({
-                        "type": "law",
-                        "source_id": law_id,
-                        "title": d.get("법령명", item.get("법령명한글", "")),
-                        "content": content,
-                        "date": d.get("공포일자", ""),
-                        "court": "",
-                    })
+                    docs.append(
+                        {
+                            "type": "law",
+                            "source_id": law_id,
+                            "title": d.get("법령명", item.get("법령명한글", "")),
+                            "content": content,
+                            "date": d.get("공포일자", ""),
+                            "court": "",
+                        }
+                    )
                 except Exception as exc:
                     log.warning("법령 상세 조회 실패", law_id=law_id, error=str(exc))
         except Exception as exc:
@@ -139,7 +179,9 @@ async def run_update() -> None:
         laws = await _crawl_laws(http, oc)
 
     all_docs = cases + laws
-    log.info("crawled legal documents", cases=len(cases), laws=len(laws), total=len(all_docs))
+    log.info(
+        "crawled legal documents", cases=len(cases), laws=len(laws), total=len(all_docs)
+    )
 
     if not all_docs:
         log.warning("no legal documents crawled — nothing to upsert")

--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -227,7 +227,7 @@ class ClauseBoundary:
 
 
 _CLAUSE_BOUNDARY_PROMPT_TEMPLATE = """다음은 계약서에서 추출된 단락 목록입니다. 각 단락 앞에 인덱스 번호가 표시됩니다.
-계약서의 각 조항이 시작되는 단락의 인덱스와 조항명을 식별해주세요.
+각 조항이 **시작되는** 단락의 인덱스만 골라주세요.
 
 단락 목록:
 {paragraphs}
@@ -240,16 +240,58 @@ _CLAUSE_BOUNDARY_PROMPT_TEMPLATE = """다음은 계약서에서 추출된 단락
   ]
 }}
 
-주의사항:
-- start 인덱스는 0부터 시작합니다
-- 조항 제목(제N조, Article N, Section N 등)이 있으면 label에 포함하세요
-- 구분이 불분명한 경우 의미 단위로 묶어 하나의 조항으로 처리하세요
-- 짧은 머리말 단독 단락은 다음 본문과 같은 조항으로 처리하세요"""
+[경계 선택 원칙]
+1. 조항 헤더(제N조, 제N항, Article N, Section N, 1. 제목, (1) 등)가 시작되는 단락만 경계로 표시합니다.
+2. 조항 본문(을은 갑에게..., 다음 각 호..., 단, ... 등 내용 텍스트)은 절대 경계로 표시하지 않습니다.
+   본문은 앞선 조항 헤더와 동일한 조항에 속합니다.
+3. 헤더 단락과 바로 뒤따르는 본문 단락은 같은 조항으로 묶어야 합니다.
+   예) [0] "제 1조 계약 목적"  [1] "을은 갑에게 서비스를 제공한다." → [0]만 경계, [1]은 본문
+4. 줄바꿈으로 인해 헤더가 짧게 나뉘더라도 조항 번호·제목이 포함된 단락만 경계입니다.
+5. 문서 형식 다양성 대응:
+   - 한국어: 제N조, 제N항, 제N목, 제N절, N. 제목, (N) 등
+   - 영문: Article N, Section N, Clause N, N. Title
+   - 번호 없는 의미 단위: 문맥상 명확히 새 주제가 시작될 때만 경계
+6. 구분이 불분명하면 이전 조항에 포함시키세요 (경계를 적게 잡는 것이 많이 잡는 것보다 안전합니다).
+- start 인덱스는 0부터 시작합니다."""
 
 # 단락당 LLM에 전달할 최대 문자 수 (긴 단락은 잘라서 구조 파악용으로만 사용)
 _PARA_PREVIEW_LEN = 150
-# 한 번에 LLM에 보낼 최대 단락 수
-_CHUNK_SIZE = 80
+# 한 번에 LLM에 보낼 최대 단락 수.
+# GPT-4o는 128k 컨텍스트. 150자 × 500단락 ≈ 2만 토큰 → 여유롭게 전체 전송 가능.
+# 대부분의 계약서는 500단락 미만이므로 실질적으로 전체 문서를 한 번에 봄.
+_CHUNK_SIZE = 500
+# 청크 간 overlap: 이전 청크 마지막 N개 단락을 다음 청크 앞에 포함해 경계 맥락 유지.
+_OVERLAP = 10
+
+
+def _serialize_paragraphs(texts: list[str], offset: int) -> str:
+    """단락 목록을 LLM 프롬프트용 '[인덱스] 미리보기' 형태로 직렬화."""
+    return "\n".join(
+        f"[{offset + i}] {text[:_PARA_PREVIEW_LEN].replace(chr(10), ' ')}"
+        + ("..." if len(text) > _PARA_PREVIEW_LEN else "")
+        for i, text in enumerate(texts)
+    )
+
+
+def _parse_boundaries_from_response(
+    raw_text: str,
+    valid_start: int,
+    valid_end: int,
+) -> list[ClauseBoundary]:
+    """LLM 응답에서 boundaries 파싱. valid_start..valid_end 범위 외 인덱스 무시."""
+    data = _extract_json(raw_text)
+    if isinstance(data, dict):
+        data = data.get("boundaries", [])
+    if not isinstance(data, list):
+        raise ValueError("Expected list under 'boundaries' key")
+    result = []
+    for item in data:
+        start_idx = int(item.get("start", valid_start))
+        if valid_start <= start_idx < valid_end:
+            result.append(
+                ClauseBoundary(start=start_idx, label=item.get("label") or None)
+            )
+    return result
 
 
 async def extract_clause_boundaries(
@@ -257,26 +299,46 @@ async def extract_clause_boundaries(
 ) -> list[ClauseBoundary]:
     """LLM을 사용해 단락 목록에서 조항 경계를 감지한다.
 
-    단락이 _CHUNK_SIZE보다 많은 경우 청크로 나눠 처리하고 인덱스를 보정한다.
+    500단락 이하(대부분의 계약서)는 전체를 한 번에 전송해 LLM이 문서 전체 맥락을
+    보고 경계를 잡도록 한다. 500단락 초과 시에는 _OVERLAP만큼 겹치는 슬라이딩
+    윈도우로 청크를 나눠 처리하여 청크 경계에서의 누락을 방지한다.
     """
     if not paragraph_texts:
         return []
 
     client = _get_client()
-    boundaries: list[ClauseBoundary] = []
+    all_boundaries: list[ClauseBoundary] = []
 
-    # 청크 단위로 처리 (긴 문서 대응)
-    for chunk_start in range(0, len(paragraph_texts), _CHUNK_SIZE):
+    # 청크 시작 인덱스 목록 생성 (overlap 적용)
+    chunk_starts = list(range(0, len(paragraph_texts), _CHUNK_SIZE - _OVERLAP))
+    # 마지막 청크가 문서 끝까지 포함되도록 보정
+    if not chunk_starts or chunk_starts[-1] + _CHUNK_SIZE < len(paragraph_texts):
+        if len(paragraph_texts) > _CHUNK_SIZE:
+            pass  # range()가 이미 처리
+    # 단일 청크인 경우
+    if len(paragraph_texts) <= _CHUNK_SIZE:
+        chunk_starts = [0]
+
+    for chunk_idx, chunk_start in enumerate(chunk_starts):
         chunk = paragraph_texts[chunk_start : chunk_start + _CHUNK_SIZE]
+        if not chunk:
+            continue
 
-        # 단락 목록을 "인덱스: 텍스트 미리보기" 형태로 직렬화
-        para_list = "\n".join(
-            f"[{chunk_start + i}] {text[:_PARA_PREVIEW_LEN].replace(chr(10), ' ')}"
-            + ("..." if len(text) > _PARA_PREVIEW_LEN else "")
-            for i, text in enumerate(chunk)
-        )
+        # overlap 구간(이전 청크 마지막 _OVERLAP개)은 경계 감지 대상에서 제외.
+        # 이미 이전 청크에서 처리된 인덱스이므로 중복 방지.
+        new_start = chunk_start if chunk_idx == 0 else chunk_start + _OVERLAP
+        new_end = chunk_start + len(chunk)
 
+        para_list = _serialize_paragraphs(chunk, chunk_start)
         prompt = _CLAUSE_BOUNDARY_PROMPT_TEMPLATE.format(paragraphs=para_list)
+
+        log.info(
+            "clause boundary LLM call",
+            chunk_idx=chunk_idx,
+            para_range=f"{chunk_start}-{chunk_start + len(chunk) - 1}",
+            new_range=f"{new_start}-{new_end - 1}",
+            total=len(paragraph_texts),
+        )
 
         try:
             raw_text = await _call_llm(client, prompt)
@@ -286,27 +348,22 @@ async def extract_clause_boundaries(
                 chunk_start=chunk_start,
                 error=str(exc),
             )
-            # 청크 실패 시 청크의 첫 단락을 단일 조항으로 처리
-            boundaries.append(ClauseBoundary(start=chunk_start, label=None))
+            # 실패 시 새 구간 첫 단락을 단일 조항 시작으로 처리
+            all_boundaries.append(ClauseBoundary(start=new_start, label=None))
             continue
 
         try:
-            data = _extract_json(raw_text)
-            # LLM은 {"boundaries": [...]} 형식으로 반환 (json_object 모드 최상위 배열 불가)
-            if isinstance(data, dict):
-                data = data.get("boundaries", [])
-            if not isinstance(data, list):
-                raise ValueError("Expected list under 'boundaries' key")
-            for item in data:
-                start_idx = int(item.get("start", chunk_start))
-                # 인덱스 범위 검증
-                if chunk_start <= start_idx < chunk_start + len(chunk):
-                    boundaries.append(
-                        ClauseBoundary(
-                            start=start_idx,
-                            label=item.get("label") or None,
-                        )
-                    )
+            chunk_boundaries = _parse_boundaries_from_response(
+                raw_text,
+                valid_start=new_start,
+                valid_end=new_end,
+            )
+            all_boundaries.extend(chunk_boundaries)
+            log.info(
+                "clause boundary chunk done",
+                chunk_start=chunk_start,
+                found=len(chunk_boundaries),
+            )
         except (json.JSONDecodeError, AttributeError, ValueError, TypeError) as exc:
             log.warning(
                 "clause boundary JSON parse failed",
@@ -314,16 +371,21 @@ async def extract_clause_boundaries(
                 error=str(exc),
                 raw=raw_text[:200],
             )
-            boundaries.append(ClauseBoundary(start=chunk_start, label=None))
+            all_boundaries.append(ClauseBoundary(start=new_start, label=None))
 
     # 중복 제거 및 정렬
     seen: set[int] = set()
     unique: list[ClauseBoundary] = []
-    for b in sorted(boundaries, key=lambda x: x.start):
+    for b in sorted(all_boundaries, key=lambda x: x.start):
         if b.start not in seen:
             seen.add(b.start)
             unique.append(b)
 
+    log.info(
+        "clause boundaries total",
+        count=len(unique),
+        total_paragraphs=len(paragraph_texts),
+    )
     return unique
 
 

--- a/app/services/parser.py
+++ b/app/services/parser.py
@@ -204,6 +204,11 @@ def clauses_from_boundaries(
 
     boundaries must be sorted by .start (ascending) and contain no duplicates.
     Each boundary marks the first paragraph of a new clause.
+
+    Short chunks (e.g. header-only lines) are carried forward and merged into
+    the next chunk instead of being dropped, so that a clause header and its
+    body always end up in the same Clause object even if the LLM accidentally
+    placed an extra boundary between them.
     """
     if not boundaries or not paragraphs:
         return []
@@ -215,6 +220,14 @@ def clauses_from_boundaries(
     breakpoints = [(b.start, b.label) for b in boundaries]
     breakpoints.append((len(paragraphs), None))  # sentinel
 
+    # Carry-over state: lines from a too-short previous chunk that must be
+    # prepended to the next chunk rather than discarded.
+    carry_lines: list[str] = []
+    carry_label: str | None = None
+    carry_page_start: int = 1
+    carry_page_end: int = 1
+    carry_anchor: Anchor | None = None
+
     for i, (start_idx, label) in enumerate(breakpoints[:-1]):
         end_idx = breakpoints[i + 1][0]
 
@@ -225,13 +238,38 @@ def clauses_from_boundaries(
         lines = [t for t, _, _ in chunk if t.strip()]
         pages = [p for _, p, _ in chunk]
         first_anchor = next((a for _, _, a in chunk if a is not None), None)
-
         page_start = pages[0] if pages else 1
         page_end = pages[-1] if pages else 1
 
-        # Use LLM-provided label; fall back to first-line extraction.
-        effective_label = label or _extract_label("\n".join(lines)) if lines else None
+        # Merge carry-over from previous too-short chunk.
+        if carry_lines:
+            lines = carry_lines + lines
+            page_start = carry_page_start
+            page_end = max(carry_page_end, page_end)
+            first_anchor = carry_anchor or first_anchor
+            # Carry-over label takes priority (it was the actual clause header).
+            label = carry_label or label
+            carry_lines = []
+            carry_label = None
+            carry_anchor = None
 
+        effective_label = label or (_extract_label("\n".join(lines)) if lines else None)
+        merged = "\n".join(lines).strip()
+
+        if not merged:
+            continue
+
+        if len(merged) < _MIN_CLAUSE_LEN:
+            # Too short on its own — likely a bare header line that the LLM
+            # split from its body. Carry forward to the next iteration.
+            carry_lines = lines
+            carry_label = effective_label
+            carry_page_start = page_start
+            carry_page_end = page_end
+            carry_anchor = first_anchor
+            continue
+
+        # Normal path: write out (splitting oversized clauses if needed).
         char_offset = _flush_lines(
             lines,
             page_start,
@@ -241,6 +279,22 @@ def clauses_from_boundaries(
             char_offset,
             clauses,
         )
+
+    # Flush any remaining carry-over (last segment was a bare header with no body).
+    if carry_lines:
+        merged = "\n".join(carry_lines).strip()
+        if merged:
+            clauses.append(
+                Clause(
+                    text=merged,
+                    label=carry_label,
+                    page_start=carry_page_start,
+                    page_end=carry_page_end,
+                    anchor=carry_anchor,
+                    start_offset=char_offset,
+                    end_offset=char_offset + len(merged),
+                )
+            )
 
     return clauses
 
@@ -304,7 +358,9 @@ def extract_paragraphs_sync(file_path: Path) -> list[RawParagraph]:
     data = file_path.read_bytes()
     suffix = file_path.suffix.lower()
 
-    log.info("extracting paragraphs", path=str(file_path), suffix=suffix, size=len(data))
+    log.info(
+        "extracting paragraphs", path=str(file_path), suffix=suffix, size=len(data)
+    )
 
     if suffix == ".pdf":
         paragraphs = _extract_paragraphs_pdf(data)

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -47,7 +47,12 @@ from app.db import (
 )
 from app.errors import PermanentError, RetryableError
 from app.services import rag as rag_svc
-from app.services.llm import MODEL, ClauseAnalysisResult, analyze_clause, summarize_document
+from app.services.llm import (
+    MODEL,
+    ClauseAnalysisResult,
+    analyze_clause,
+    summarize_document,
+)
 
 log = structlog.get_logger()
 
@@ -159,7 +164,8 @@ async def _analyze_single_clause(
             {
                 "id": r.get("source_id") or "",
                 "type": r.get("type", "prec"),
-                "title": r.get("title") or ("판례" if r.get("type") == "prec" else "법령"),
+                "title": r.get("title")
+                or ("판례" if r.get("type") == "prec" else "법령"),
                 "snippet": r.get("content", "")[:200],
                 "whyRelevant": "",
                 "source": f"https://www.law.go.kr/판례/{r.get('source_id', '')}",
@@ -233,9 +239,7 @@ def _build_recommended_actions(issue_types: list[str]) -> list[str]:
     return [actions_map[it] for it in issue_types if it in actions_map]
 
 
-async def _handle_retrieve_evidence(
-    pool: asyncpg.Pool, msg: dict[str, Any]
-) -> None:
+async def _handle_retrieve_evidence(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
     """Re-run RAG for an evidence set and update its citations.
 
     Message format:


### PR DESCRIPTION
## 변경사항
- `_run_weekly_legal_update()` 시작 시 `run_update()` 즉시 1회 실행 후 주기 루프 진입
- 초기 실행 실패 시 `log.exception()` 후 계속 진행, 다음 주 주기에서 재시도
- `legal_updater.py`, `analysis.py` ruff 포맷 적용

## 원인
워커가 시작되면 다음 월요일 04:00 KST까지만 대기하여 `cases` Qdrant 컬렉션이 한 번도 채워지지 않았다.  
결과적으로 증거 패널에 실제 판례가 표시되지 않고 유사 계약 조항만 나타났다.

## QA 결과
- ruff check: PASS
- ruff format: PASS
- 스케줄링 경계 조건(월요일 04:00 정각/이전/이후) 검증 완료
- 초기 실행 실패 시 예외 처리 패턴 확인

Closes #46