### PR TITLE
fix(#48): clauses RAG 제거 및 법령 크롤링 버그 수정

### DIFF
--- a/app/services/legal_updater.py
+++ b/app/services/legal_updater.py
@@ -17,7 +17,8 @@ from app.services.rag import CASES_COLLECTION_NAME, _get_client, ensure_cases_co
 log = structlog.get_logger()
 
 _API_BASE = "https://www.law.go.kr/DRF"
-_QUERIES = [
+# 판례 검색 키워드 (전체 텍스트 검색)
+_PREC_QUERIES = [
     "불공정계약",
     "손해배상",
     "계약해지",
@@ -25,6 +26,16 @@ _QUERIES = [
     "위약금",
     "기밀유지",
     "지식재산권",
+]
+# 법령 검색 키워드 (법령명 + 전체 검색, section=all)
+_LAW_QUERIES = [
+    "약관",
+    "손해배상",
+    "계약",
+    "지식재산",
+    "하도급",
+    "공정거래",
+    "개인정보",
 ]
 _DISPLAY = 10
 
@@ -44,7 +55,7 @@ async def _crawl_cases(client: httpx.AsyncClient, oc: str) -> list[dict]:
     seen: set[str] = set()
     docs: list[dict] = []
 
-    for query in _QUERIES:
+    for query in _PREC_QUERIES:
         try:
             data = await _fetch(
                 client,
@@ -103,7 +114,7 @@ async def _crawl_laws(client: httpx.AsyncClient, oc: str) -> list[dict]:
     seen: set[str] = set()
     docs: list[dict] = []
 
-    for query in _QUERIES:
+    for query in _LAW_QUERIES:
         try:
             data = await _fetch(
                 client,
@@ -114,13 +125,16 @@ async def _crawl_laws(client: httpx.AsyncClient, oc: str) -> list[dict]:
                     "type": "JSON",
                     "query": query,
                     "display": _DISPLAY,
+                    "section": "all",
                 },
             )
             items = data.get("LawSearch", {}).get("law", [])
             if isinstance(items, dict):
                 items = [items]
+            elif not isinstance(items, list):
+                items = []
             for item in items:
-                law_id = str(item.get("법령ID", ""))
+                law_id = str(item.get("법령일련번호", ""))
                 if not law_id or law_id in seen:
                     continue
                 seen.add(law_id)

--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -1,8 +1,7 @@
-"""RAG service: stores and retrieves clause embeddings from Qdrant."""
+"""RAG service: retrieves 판례/법령 from Qdrant cases collection."""
 
 from __future__ import annotations
 
-from datetime import datetime
 from typing import Any
 
 import structlog
@@ -12,8 +11,6 @@ from qdrant_client.http.models import (
     FieldCondition,
     Filter,
     MatchValue,
-    PointStruct,
-    Range,
     VectorParams,
 )
 
@@ -22,7 +19,6 @@ from app.services.embeddings import EMBEDDING_DIM, embed
 
 log = structlog.get_logger()
 
-COLLECTION_NAME = "clauses"
 CASES_COLLECTION_NAME = "cases"
 
 _client: AsyncQdrantClient | None = None
@@ -35,119 +31,19 @@ def _get_client() -> AsyncQdrantClient:
     return _client
 
 
-async def _ensure_collection(name: str) -> None:
+async def ensure_cases_collection() -> None:
+    """Create the cases collection if it does not already exist."""
     client = _get_client()
     collections = await client.get_collections()
     existing = {c.name for c in collections.collections}
-    if name not in existing:
+    if CASES_COLLECTION_NAME not in existing:
         await client.create_collection(
-            collection_name=name,
+            collection_name=CASES_COLLECTION_NAME,
             vectors_config=VectorParams(size=EMBEDDING_DIM, distance=Distance.COSINE),
         )
-        log.info("qdrant collection created", collection=name)
+        log.info("qdrant collection created", collection=CASES_COLLECTION_NAME)
     else:
-        log.info("qdrant collection exists", collection=name)
-
-
-async def ensure_collection() -> None:
-    """Create the clauses collection if it does not already exist."""
-    await _ensure_collection(COLLECTION_NAME)
-
-
-async def ensure_cases_collection() -> None:
-    """Create the cases collection if it does not already exist."""
-    await _ensure_collection(CASES_COLLECTION_NAME)
-
-
-async def upsert_clauses(
-    points: list[dict[str, Any]],
-) -> None:
-    """Upsert clause vectors into Qdrant.
-
-    Each point must have:
-        id (str UUID or int),
-        vector (list[float]),
-        payload: {
-            contract_id, clause_id, label, org_id, created_at (ISO str)
-        }
-    """
-    client = _get_client()
-    qdrant_points = [
-        PointStruct(
-            id=p["id"],
-            vector=p["vector"],
-            payload=p["payload"],
-        )
-        for p in points
-    ]
-
-    await client.upsert(
-        collection_name=COLLECTION_NAME,
-        points=qdrant_points,
-    )
-    log.info("upserted clause vectors", count=len(qdrant_points))
-
-
-async def search_similar_clauses(
-    query_text: str,
-    top_k: int = 3,
-    org_id: str | None = None,
-    date_from: datetime | None = None,
-    date_to: datetime | None = None,
-) -> list[dict[str, Any]]:
-    """Search Qdrant for clauses similar to query_text.
-
-    Returns a list of dicts with keys: clause_id, contract_id, label,
-    score, payload.
-    """
-    client = _get_client()
-    vectors = await embed([query_text])
-    query_vector = vectors[0]
-
-    # Build optional filters.
-    must: list[Any] = []
-
-    if org_id:
-        must.append(
-            FieldCondition(
-                key="org_id",
-                match=MatchValue(value=org_id),
-            )
-        )
-
-    if date_from or date_to:
-        range_kwargs: dict[str, Any] = {}
-        if date_from:
-            range_kwargs["gte"] = date_from.timestamp()
-        if date_to:
-            range_kwargs["lte"] = date_to.timestamp()
-        must.append(
-            FieldCondition(
-                key="created_at_ts",
-                range=Range(**range_kwargs),
-            )
-        )
-
-    query_filter = Filter(must=must) if must else None
-
-    response = await client.query_points(
-        collection_name=COLLECTION_NAME,
-        query=query_vector,
-        limit=top_k,
-        query_filter=query_filter,
-        with_payload=True,
-    )
-
-    return [
-        {
-            "clause_id": r.payload.get("clause_id"),
-            "contract_id": r.payload.get("contract_id"),
-            "label": r.payload.get("label"),
-            "score": r.score,
-            "payload": r.payload,
-        }
-        for r in response.points
-    ]
+        log.info("qdrant collection exists", collection=CASES_COLLECTION_NAME)
 
 
 async def search_legal_references(
@@ -164,7 +60,6 @@ async def search_legal_references(
     """
     client = _get_client()
 
-    # Silently skip if the collection doesn't exist yet.
     collections = await client.get_collections()
     existing = {c.name for c in collections.collections}
     if CASES_COLLECTION_NAME not in existing:

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -11,9 +11,9 @@ Processing pipeline:
     2. Load clauses from DB
     3. Parallel analysis (max 5 concurrent):
        a. LLM analysis → risk_level, confidence, issue_types, summary, rationale
-       b. RAG search → topK=3 similar clauses
+       b. RAG search → topK=5 판례/법령 검색 (cases 컬렉션)
        c. Save clause_result to DB (including confidence)
-       d. Save evidence_set to DB
+       d. Save evidence_set to DB (citations: 판례/법령만 포함)
     4. Analysis status completed
     5. On failure → status failed
 
@@ -37,11 +37,8 @@ from openai import APIStatusError
 
 from app.db import (
     get_clauses_for_contract,
-    get_evidence_set_with_clause,
-    get_org_id_for_analysis,
     insert_clause_result,
     insert_evidence_set,
-    update_evidence_set_citations,
     update_risk_analysis,
     update_risk_analysis_summary,
 )
@@ -101,7 +98,6 @@ async def _analyze_single_clause(
     analysis_id: str,
     clause: asyncpg.Record,
     semaphore: asyncio.Semaphore,
-    org_id: str | None = None,
 ) -> ClauseAnalysisResult:
     """Run LLM + RAG for one clause, persist results, and return the LLM result."""
     async with semaphore:
@@ -133,34 +129,13 @@ async def _analyze_single_clause(
             )
             raise
 
-        # RAG: find similar clauses scoped to the same organization.
-        # Passing org_id ensures we only surface evidence from the org's own
-        # historical contracts, preventing cross-tenant data leakage.
-        similar, legal_refs = await asyncio.gather(
-            rag_svc.search_similar_clauses(
-                query_text=clause_text,
-                top_k=3,
-                org_id=org_id,
-            ),
-            rag_svc.search_legal_references(
-                query_text=clause_text,
-                top_k=3,
-            ),
+        # RAG: 판례/법령만 증거로 사용
+        legal_refs = await rag_svc.search_legal_references(
+            query_text=clause_text,
+            top_k=5,
         )
 
-        # Build citations: clause-based + legal references (판례/법령).
         citations = [
-            {
-                "id": s.get("clause_id") or "",
-                "type": "clause",
-                "title": s.get("label") or "유사 조항",
-                "snippet": s.get("payload", {}).get("content", "")[:200],
-                "whyRelevant": "",
-                "source": s.get("contract_id"),
-                "score": s.get("score"),
-            }
-            for s in similar
-        ] + [
             {
                 "id": r.get("source_id") or "",
                 "type": r.get("type", "prec"),
@@ -239,66 +214,6 @@ def _build_recommended_actions(issue_types: list[str]) -> list[str]:
     return [actions_map[it] for it in issue_types if it in actions_map]
 
 
-async def _handle_retrieve_evidence(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
-    """Re-run RAG for an evidence set and update its citations.
-
-    Message format:
-        {
-            "type": "RETRIEVE_EVIDENCE",
-            "evidenceSetId": "<ID>",
-            "orgId": "<org UUID>"   (optional)
-        }
-    """
-    evidence_set_id = msg.get("evidenceSetId")
-    if not evidence_set_id:
-        raise PermanentError("RETRIEVE_EVIDENCE message missing evidenceSetId")
-
-    log.info("RETRIEVE_EVIDENCE started", evidence_set_id=evidence_set_id)
-
-    try:
-        row = await get_evidence_set_with_clause(pool, evidence_set_id)
-    except asyncpg.PostgresConnectionError as exc:
-        raise RetryableError(f"DB error fetching evidence set: {exc}") from exc
-
-    if row is None:
-        raise PermanentError(f"evidence_set not found: {evidence_set_id}")
-
-    clause_text: str = row["clause_content"]
-    org_id: str | None = msg.get("orgId") or row["org_id"]
-    top_k: int = row["top_k"] or 3
-
-    similar = await rag_svc.search_similar_clauses(
-        query_text=clause_text,
-        top_k=top_k,
-        org_id=org_id,
-    )
-
-    citations = [
-        {
-            "id": s.get("clause_id") or "",
-            "type": "clause",
-            "title": s.get("label") or "유사 조항",
-            "snippet": s.get("payload", {}).get("content", "")[:200],
-            "whyRelevant": "",
-            "source": s.get("contract_id"),
-            "score": s.get("score"),
-            "url": f"/contracts/{s.get('contract_id')}/clauses/{s.get('clause_id')}",
-        }
-        for s in similar
-    ]
-
-    try:
-        await update_evidence_set_citations(pool, evidence_set_id, citations)
-    except asyncpg.PostgresConnectionError as exc:
-        raise RetryableError(f"DB error updating citations: {exc}") from exc
-
-    log.info(
-        "RETRIEVE_EVIDENCE completed",
-        evidence_set_id=evidence_set_id,
-        citations_count=len(citations),
-    )
-
-
 async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
     # Validate required fields — raise PermanentError if missing
     try:
@@ -314,10 +229,6 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
         await update_risk_analysis(pool, analysis_id, status="running")
     except asyncpg.PostgresConnectionError as exc:
         raise RetryableError(f"DB connection error on status update: {exc}") from exc
-
-    # Ensure Qdrant collection exists before running RAG searches.
-    # This handles the case where Qdrant restarts and the collection is gone.
-    await rag_svc.ensure_collection()
 
     # Step 2 — load clauses.
     try:
@@ -337,19 +248,11 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 
     log.info("loaded clauses", count=len(clauses))
 
-    # Fetch org_id to scope RAG search to this organization only.
-    org_id = await get_org_id_for_analysis(pool, analysis_id)
-    if org_id is None:
-        log.warning(
-            "org_id not found for analysis — RAG will search across all orgs",
-            analysis_id=analysis_id,
-        )
-
     # Step 3 — parallel analysis with bounded concurrency.
     # Use return_exceptions=True so a single clause failure does not abort others.
     semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
     tasks = [
-        _analyze_single_clause(pool, analysis_id, clause, semaphore, org_id=org_id)
+        _analyze_single_clause(pool, analysis_id, clause, semaphore)
         for clause in clauses
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
@@ -427,36 +330,9 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 def make_handler(
     pool: asyncpg.Pool,
 ) -> Callable[[dict[str, Any]], Awaitable[None]]:
-    """Return an async message handler bound to the given DB pool.
-
-    Handles two message types on analysis.jobs:
-      1. Analysis jobs: {"contractId": "...", "analysisId": "..."}
-      2. RETRIEVE_EVIDENCE: {"type": "RETRIEVE_EVIDENCE", "evidenceSetId": "...", "orgId": "..."}
-    """
+    """Return an async message handler bound to the given DB pool."""
 
     async def handler(msg: dict[str, Any]) -> None:
-        # Route by message type.
-        msg_type = msg.get("type")
-        if msg_type == "RETRIEVE_EVIDENCE":
-            evidence_set_id = msg.get("evidenceSetId", "unknown")
-            try:
-                await _handle_retrieve_evidence(pool, msg)
-            except PermanentError as exc:
-                log.error(
-                    "permanent RETRIEVE_EVIDENCE failure",
-                    evidence_set_id=evidence_set_id,
-                    error=str(exc),
-                )
-                raise
-            except (RetryableError, Exception) as exc:
-                log.error(
-                    "retryable RETRIEVE_EVIDENCE failure",
-                    evidence_set_id=evidence_set_id,
-                    error=str(exc),
-                )
-                raise
-            return
-
         analysis_id = msg.get("analysisId", "unknown")
         contract_id = msg.get("contractId", "unknown")
         try:

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -1,4 +1,4 @@
-"""Document ingestion worker: parses documents and stores embeddings.
+"""Document ingestion worker: parses documents and stores clauses in DB.
 
 Message format (from signsafe-api/internal/queue/rabbitmq.go):
     {
@@ -8,22 +8,19 @@ Message format (from signsafe-api/internal/queue/rabbitmq.go):
     }
 
 Processing pipeline:
-    1. Receive message → confirm ingestion_job exists in DB
-    2. Job status → parsing, progress 0%
-    3. Download file from S3
-    4. Parse into clauses
-    5. Job status → chunking, progress 40%
-    6. Batch-insert clauses to DB
-    7. Job status → indexing, progress 70%
-    8. Generate embeddings → upsert to Qdrant
-    9. Job status → completed, progress 100%
-   10. On failure → job status failed, store error message
+    1. Job status → parsing, progress 0%
+    2. Download file from S3, extract paragraphs
+    3. LLM-based clause boundary detection (regex fallback on failure)
+    4. Job status → chunking, progress 60%
+    5. Batch-insert clauses to DB
+    6. Job status → completed, progress 100%
+    7. On failure → job status failed, store error message
 
 Error classification:
     PermanentError — missing required fields, unsupported file type, PDF parse
         errors. Message is acked; no DLQ routing.
-    RetryableError — S3 download failures, DB connection errors, Qdrant
-        unavailability. Consumer retries with exponential back-off.
+    RetryableError — S3 download failures, DB connection errors. Consumer
+        retries with exponential back-off.
 """
 
 from __future__ import annotations
@@ -44,16 +41,13 @@ from botocore.exceptions import BotoCoreError, ClientError
 
 from app.config import settings
 from app.db import (
-    get_org_id_for_contract,
     insert_clauses_batch,
     update_contract_status,
     update_ingestion_job,
 )
 from app.errors import PermanentError, RetryableError
-from app.services import embeddings as emb_svc
 from app.services import llm as llm_svc
 from app.services import parser as parser_svc
-from app.services import rag as rag_svc
 
 log = structlog.get_logger()
 
@@ -78,15 +72,6 @@ def _guess_suffix(file_path: str) -> str:
     """Return the file suffix from the S3 key."""
     ext = pathlib.Path(file_path).suffix.lower()
     return ext if ext else ".pdf"
-
-
-def _clause_id_to_qdrant_id(clause_id: str) -> str:
-    """Convert a 26-char alphanumeric ID to a UUID string for Qdrant.
-
-    Qdrant requires point IDs to be unsigned integers or UUID strings.
-    We pad/hash to produce a deterministic UUID.
-    """
-    return str(uuid.uuid5(uuid.NAMESPACE_OID, clause_id))
 
 
 async def _download_and_extract_paragraphs(
@@ -180,32 +165,6 @@ def _build_clause_dicts(
     return clause_dicts
 
 
-def _build_qdrant_points(
-    clause_dicts: list[dict[str, Any]],
-    vectors: list[list[float]],
-    contract_id: str,
-    org_id: str | None,
-    created_at: datetime,
-) -> list[dict[str, Any]]:
-    """Assemble Qdrant point dicts from clause dicts and embedding vectors."""
-    return [
-        {
-            "id": _clause_id_to_qdrant_id(c["id"]),
-            "vector": vectors[i],
-            "payload": {
-                "clause_id": c["id"],
-                "contract_id": contract_id,
-                "label": c.get("label"),
-                "content": c["content"][:500],  # truncated for RAG snippet display
-                "org_id": org_id,
-                "created_at": created_at.isoformat(),
-                "created_at_ts": created_at.timestamp(),
-            },
-        }
-        for i, c in enumerate(clause_dicts)
-    ]
-
-
 async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
     # Validate required fields — raise PermanentError if missing
     try:
@@ -241,7 +200,7 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
             pool,
             job_id,
             status="chunking",
-            progress=40,
+            progress=60,
             current_step="조항 분절 완료, DB 저장 중",
         )
 
@@ -257,37 +216,7 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 
         log.info("clauses saved to DB", count=len(clause_dicts))
 
-        # Step 3 → indexing
-        await update_ingestion_job(
-            pool,
-            job_id,
-            status="indexing",
-            progress=70,
-            current_step="임베딩 생성 및 Qdrant 저장 중",
-        )
-
-        await rag_svc.ensure_collection()
-
-        try:
-            org_id = await get_org_id_for_contract(pool, contract_id)
-        except asyncpg.PostgresConnectionError as exc:
-            raise RetryableError(f"DB connection error fetching org_id: {exc}") from exc
-
-        if org_id is None:
-            log.warning(
-                "org_id not found for contract — Qdrant points will have null org_id",
-                contract_id=contract_id,
-            )
-
-        texts = [c["content"] for c in clause_dicts]
-        vectors = await emb_svc.embed(texts)
-        qdrant_points = _build_qdrant_points(
-            clause_dicts, vectors, contract_id, org_id, now_ts
-        )
-
-        await rag_svc.upsert_clauses(qdrant_points)
-
-        # Step 4 → completed
+        # Step 3 → completed
         await update_ingestion_job(
             pool, job_id, status="completed", progress=100, current_step="완료"
         )


### PR DESCRIPTION
## 변경사항
- **rag.py**: clauses 컬렉션(`upsert_clauses`, `search_similar_clauses`, `ensure_collection`) 전부 제거. 판례/법령(`cases` 컬렉션) 검색만 유지
- **ingestion.py**: Qdrant 임베딩/upsert(indexing) 단계 제거. 파이프라인 단순화: parsing → chunking(DB insert) → completed
- **analysis.py**: `search_similar_clauses`, `_handle_retrieve_evidence` 제거. citations에 판례/법령(top_k=5)만 포함
- **legal_updater.py**: `법령ID` → `법령일련번호` 수정, 법령/판례 쿼리 분리(`_PREC_QUERIES`/`_LAW_QUERIES`), `section=all` 파라미터 추가로 법령 0건 버그 수정

## QA 결과
- ruff check: PASS
- ruff format: PASS
- 제거된 심볼 참조 없음 확인
- docstring 실제 파이프라인과 일치 확인

Closes #48