### PR TITLE
feat: citation에 whyRelevant 설명 자동 생성

### DIFF
--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -74,6 +74,42 @@ def _law_source_url(ref_type: str, source_id: str) -> str:
     return f"https://www.law.go.kr/precInfoP.do?precSeq={source_id}"
 
 
+# 이슈 타입별 한국어 레이블
+_ISSUE_LABELS: dict[str, str] = {
+    "LIABILITY_LIMITATION": "손해배상 제한",
+    "TERMINATION_RIGHT": "일방적 계약 해지권",
+    "IP_OWNERSHIP": "지식재산권 귀속",
+    "PENALTY_CLAUSE": "위약금/페널티",
+    "FORCE_MAJEURE": "불가항력",
+    "GOVERNING_LAW": "준거법/관할",
+    "CONFIDENTIALITY": "기밀유지",
+    "INDEMNITY": "면책",
+    "PAYMENT_TERMS": "지급 조건",
+}
+
+
+def _generate_why_relevant(
+    ref_type: str,
+    issue_types: list[str],
+) -> str:
+    """Generate a brief Korean explanation of why this citation is relevant.
+
+    Uses the clause's issue types to produce a template-based explanation
+    without an additional LLM call.
+    """
+    if not issue_types:
+        if ref_type == "law":
+            return "해당 조항의 법적 근거로 활용됩니다."
+        return "유사 분쟁에서의 판단 사례로 참고됩니다."
+
+    labels = [_ISSUE_LABELS.get(it, it) for it in issue_types[:2]]
+    issue_text = " 및 ".join(labels)
+
+    if ref_type == "law":
+        return f"{issue_text} 관련 법적 기준을 규정하며, 해당 조항의 적법성 판단에 활용됩니다."
+    return f"{issue_text} 관련 분쟁에서의 판례로, 해당 조항의 법적 유효성 평가에 참고됩니다."
+
+
 def _classify_exception(exc: BaseException) -> type[RetryableError | PermanentError]:
     """Map an arbitrary exception to a retryable vs permanent category.
 
@@ -153,7 +189,9 @@ async def _analyze_single_clause(
                 "title": r.get("title")
                 or ("판례" if r.get("type") == "prec" else "법령"),
                 "snippet": r.get("content", "")[:200],
-                "whyRelevant": "",
+                "whyRelevant": _generate_why_relevant(
+                    r.get("type", "prec"), llm_result.issue_types
+                ),
                 "source": _law_source_url(
                     r.get("type", "prec"), r.get("source_id", "")
                 ),


### PR DESCRIPTION
## 변경사항

`_generate_why_relevant()` 헬퍼 추가:
- 이슈 타입(LIABILITY_LIMITATION, IP_OWNERSHIP 등)을 한국어 레이블로 변환
- 인용 타입(prec/law)에 따라 템플릿 문장 생성
- `whyRelevant: ""` → 의미 있는 설명 텍스트로 교체

## 효과

- CitationCard의 "Why relevant" 섹션이 이제 실제 내용을 표시
- 추가 LLM 호출 없이 기존 `issue_types` 활용 → 비용/latency 영향 없음
- 이슈 타입이 없는 경우에도 기본 설명 반환

## 생성 예시

- prec + IP_OWNERSHIP: "지식재산권 귀속 관련 분쟁에서의 판례로, 해당 조항의 법적 유효성 평가에 참고됩니다."
- law + LIABILITY_LIMITATION: "손해배상 제한 관련 법적 기준을 규정하며, 해당 조항의 적법성 판단에 활용됩니다."