### PR TITLE
fix(#63): DLQ consumer job 상태 미업데이트 + S3 download 타임아웃 누락

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -81,11 +81,15 @@ async def main() -> None:
     queue_conn = await connect_queue()
 
     # Import workers here to avoid circular imports at module level.
+    from app.workers.analysis import make_dlq_handler as make_analysis_dlq_handler
     from app.workers.analysis import make_handler as make_analysis_handler
+    from app.workers.ingestion import make_dlq_handler as make_ingestion_dlq_handler
     from app.workers.ingestion import make_handler as make_ingestion_handler
 
     ingestion_handler = make_ingestion_handler(db)
     analysis_handler = make_analysis_handler(db)
+    ingestion_dlq_handler = make_ingestion_dlq_handler(db)
+    analysis_dlq_handler = make_analysis_dlq_handler(db)
 
     log.info("connections established, starting workers")
 
@@ -112,8 +116,8 @@ async def main() -> None:
         asyncio.gather(
             consume(queue_conn, INGESTION_QUEUE, ingestion_handler),
             consume(queue_conn, ANALYSIS_QUEUE, analysis_handler),
-            consume_dlq(queue_conn, INGESTION_DLQ),
-            consume_dlq(queue_conn, ANALYSIS_DLQ),
+            consume_dlq(queue_conn, INGESTION_DLQ, ingestion_dlq_handler),
+            consume_dlq(queue_conn, ANALYSIS_DLQ, analysis_dlq_handler),
             _run_weekly_legal_update(),
         )
     )

--- a/app/queue.py
+++ b/app/queue.py
@@ -59,11 +59,17 @@ async def _declare_queue_with_dlq(
 async def consume_dlq(
     connection: aio_pika.abc.AbstractRobustConnection,
     dlq_name: str,
+    on_dlq_message: Callable[[dict[str, Any]], Awaitable[None]] | None = None,
 ) -> None:
     """Consume messages from a DLQ and log each one as an error.
 
     DLQ messages represent processing failures. This consumer ensures they are
     never silently accumulated — every entry is logged so operators can triage.
+
+    If ``on_dlq_message`` is provided it is called with the parsed message body
+    so the caller can update persistent state (e.g. mark the job as failed in
+    the DB).  Errors from the callback are logged but do NOT prevent the message
+    from being acked.
     """
     channel = await connection.channel()
     await channel.set_qos(prefetch_count=1)
@@ -86,6 +92,15 @@ async def consume_dlq(
                         headers=headers,
                         message_id=message.message_id,
                     )
+                    if on_dlq_message is not None:
+                        try:
+                            body = json.loads(body_str)
+                            await on_dlq_message(body)
+                        except Exception:
+                            log.exception(
+                                "DLQ on_dlq_message callback failed",
+                                queue=dlq_name,
+                            )
                 except Exception:
                     log.exception("failed to log DLQ message", queue=dlq_name)
 

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -525,3 +525,34 @@ def make_handler(
             raise  # re-raise; queue.consume retries or nacks → DLQ
 
     return handler
+
+
+def make_dlq_handler(
+    pool: asyncpg.Pool,
+) -> Callable[[dict[str, Any]], Awaitable[None]]:
+    """Return a DLQ callback that marks the analysis as failed in the DB.
+
+    Called by consume_dlq for every message that could not be processed after
+    all retries.  Idempotent: an analysis that is already 'failed' stays 'failed'.
+    """
+
+    async def on_dlq_message(msg: dict[str, Any]) -> None:
+        analysis_id = msg.get("analysisId")
+        if not analysis_id:
+            log.warning("analysis DLQ message missing analysisId", msg=str(msg)[:200])
+            return
+        try:
+            await update_risk_analysis(
+                pool,
+                analysis_id,
+                status="failed",
+                error_message="DLQ: 최대 재시도 횟수 초과",
+            )
+            log.info("analysis DLQ: analysis marked failed", analysis_id=analysis_id)
+        except Exception:
+            log.exception(
+                "analysis DLQ: failed to update analysis status",
+                analysis_id=analysis_id,
+            )
+
+    return on_dlq_message

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -37,6 +37,7 @@ from typing import Any
 import asyncpg
 import boto3
 import structlog
+from botocore.config import Config
 from botocore.exceptions import BotoCoreError, ClientError
 
 from app.config import settings
@@ -59,6 +60,7 @@ def _make_s3_client() -> Any:
         aws_access_key_id=settings.s3_access_key,
         aws_secret_access_key=settings.s3_secret_key,
         region_name="us-east-1",
+        config=Config(connect_timeout=10, read_timeout=120),
     )
 
 
@@ -277,3 +279,42 @@ def make_handler(
             raise  # re-raise; queue.consume retries or nacks → DLQ
 
     return handler
+
+
+def make_dlq_handler(
+    pool: asyncpg.Pool,
+) -> Callable[[dict[str, Any]], Awaitable[None]]:
+    """Return a DLQ callback that marks the ingestion job as failed in the DB.
+
+    Called by consume_dlq for every message that could not be processed after
+    all retries.  Idempotent: a job that is already 'failed' stays 'failed'.
+    """
+
+    async def on_dlq_message(msg: dict[str, Any]) -> None:
+        job_id = msg.get("jobId")
+        contract_id = msg.get("contractId")
+        if not job_id:
+            log.warning("ingestion DLQ message missing jobId", msg=str(msg)[:200])
+            return
+        try:
+            await update_ingestion_job(
+                pool,
+                job_id,
+                status="failed",
+                progress=0,
+                error_message="DLQ: 최대 재시도 횟수 초과",
+            )
+            if contract_id:
+                await update_contract_status(pool, contract_id, "failed")
+            log.info(
+                "ingestion DLQ: job marked failed",
+                job_id=job_id,
+                contract_id=contract_id,
+            )
+        except Exception:
+            log.exception(
+                "ingestion DLQ: failed to update job status",
+                job_id=job_id,
+            )
+
+    return on_dlq_message


### PR DESCRIPTION
## 변경사항
- `consume_dlq()`에 `on_dlq_message` 콜백 파라미터 추가
- `ingestion.make_dlq_handler()` — DLQ 수신 시 ingestion job + contract를 `failed`로 업데이트
- `analysis.make_dlq_handler()` — DLQ 수신 시 analysis를 `failed`로 업데이트
- `main.py`에서 각 DLQ 핸들러 바인딩
- `_make_s3_client()` connect_timeout=10s, read_timeout=120s 추가 (무한 hang 방지)

## 문제
DLQ로 라우팅된 메시지에 대해 DB 상태가 `parsing`/`running`으로 영구 stuck됨.
재시도 시마다 `_process()`가 status를 `parsing`으로 리셋하는데, 최후 실패 후
`failed` 업데이트 자체가 실패하면 DB에 `parsing`이 남음.

## QA 결과
- DLQ 메시지 수신 시 job/analysis 상태 `failed` 업데이트
- S3 무한 hang → 120초 타임아웃 후 RetryableError

Closes #63