### PR TITLE
perf(#62): LLM boundary skip + 임베딩 배치화

### DIFF
--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -50,6 +50,7 @@ async def search_legal_references(
     query_text: str,
     top_k: int = 3,
     ref_type: str | None = None,
+    query_vector: list[float] | None = None,
 ) -> list[dict[str, Any]]:
     """Search Qdrant cases collection for relevant 판례/법령.
 
@@ -57,6 +58,8 @@ async def search_legal_references(
         query_text: clause text to search against.
         top_k: number of results to return.
         ref_type: optional filter — "prec" for 판례, "law" for 법령, None for both.
+        query_vector: pre-computed embedding vector. When provided, the embed()
+            call is skipped, saving one API round-trip.
     """
     client = _get_client()
 
@@ -65,8 +68,9 @@ async def search_legal_references(
     if CASES_COLLECTION_NAME not in existing:
         return []
 
-    vectors = await embed([query_text])
-    query_vector = vectors[0]
+    if query_vector is None:
+        vectors = await embed([query_text])
+        query_vector = vectors[0]
 
     must: list[Any] = []
     if ref_type:

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -44,6 +44,7 @@ from app.db import (
 )
 from app.errors import PermanentError, RetryableError
 from app.services import rag as rag_svc
+from app.services.embeddings import embed
 from app.services.llm import (
     MODEL,
     ClauseAnalysisResult,
@@ -145,8 +146,13 @@ async def _analyze_single_clause(
     analysis_id: str,
     clause: asyncpg.Record,
     semaphore: asyncio.Semaphore,
+    clause_vector: list[float] | None = None,
 ) -> ClauseAnalysisResult:
-    """Run LLM + RAG for one clause, persist results, and return the LLM result."""
+    """Run LLM + RAG for one clause, persist results, and return the LLM result.
+
+    clause_vector: pre-computed embedding for this clause.  When provided, the
+        RAG step skips the embed() call, saving one API round-trip per clause.
+    """
     async with semaphore:
         clause_id: str = clause["id"]
         clause_text: str = clause["content"]
@@ -176,10 +182,12 @@ async def _analyze_single_clause(
             )
             raise
 
-        # RAG: 판례/법령만 증거로 사용
+        # RAG: 판례/법령만 증거로 사용.
+        # Pass pre-computed vector to skip the per-clause embed() round-trip.
         legal_refs = await rag_svc.search_legal_references(
             query_text=clause_text,
             top_k=5,
+            query_vector=clause_vector,
         )
 
         citations = [
@@ -299,12 +307,26 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 
     log.info("loaded clauses", count=len(clauses))
 
+    # Pre-batch embed all clause texts in a single API call.
+    # Each clause would otherwise embed individually inside search_legal_references,
+    # resulting in N serial round-trips.  One batch call reduces this to O(1).
+    clause_texts = [c["content"] for c in clauses]
+    try:
+        clause_vectors: list[list[float] | None] = await embed(clause_texts)
+        log.info("batch embedding complete", clause_count=len(clause_vectors))
+    except Exception as exc:
+        log.warning(
+            "batch embedding failed — RAG will embed per-clause",
+            error=str(exc),
+        )
+        clause_vectors = [None] * len(clauses)
+
     # Step 3 — parallel analysis with bounded concurrency.
     # Use return_exceptions=True so a single clause failure does not abort others.
     semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
     tasks = [
-        _analyze_single_clause(pool, analysis_id, clause, semaphore)
-        for clause in clauses
+        _analyze_single_clause(pool, analysis_id, clause, semaphore, vec)
+        for clause, vec in zip(clauses, clause_vectors)
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/app/workers/ingestion.py
+++ b/app/workers/ingestion.py
@@ -114,7 +114,25 @@ async def _download_and_extract_paragraphs(
 async def _split_clauses_with_llm(
     paragraphs: list[Any],
 ) -> list[Any]:
-    """Use LLM to detect clause boundaries; fall back to regex on failure."""
+    """Use LLM to detect clause boundaries; fall back to regex on failure.
+
+    Fast path: if the regex pass already finds ≥2 clauses (the common case
+    after the sub-split fix), the LLM call (3-5 s) is skipped entirely.
+    """
+    # Fast path: regex first — if sufficient, skip the LLM round-trip.
+    regex_clauses = parser_svc._split_into_clauses_regex(paragraphs)
+    if len(regex_clauses) >= 2:
+        log.info(
+            "regex found sufficient clauses — skipping LLM boundary detection",
+            clause_count=len(regex_clauses),
+        )
+        return regex_clauses
+
+    # Regex found 0-1 clause — structure is ambiguous; try LLM for better segmentation.
+    log.info(
+        "regex found few clauses — attempting LLM boundary detection",
+        regex_clause_count=len(regex_clauses),
+    )
     paragraph_texts = [text for text, _, _ in paragraphs]
 
     try:
@@ -134,10 +152,9 @@ async def _split_clauses_with_llm(
             error=str(exc),
         )
 
-    # Regex fallback
-    clauses = parser_svc._split_into_clauses_regex(paragraphs)
-    log.info("regex fallback clause split complete", clause_count=len(clauses))
-    return clauses
+    # Regex fallback (reuse already-computed result)
+    log.info("using regex clause split", clause_count=len(regex_clauses))
+    return regex_clauses
 
 
 def _build_clause_dicts(


### PR DESCRIPTION
## 변경사항
- **ingestion**: regex가 ≥2개 조항 발견 시 LLM 경계 탐지 스킵 — 대부분 계약서에서 3-5초 절약
- **analysis**: 분석 루프 전 전체 조항 텍스트를 단일 `embed()` 호출로 배치 처리 — N번 → 1번 API round-trip
- **rag**: `search_legal_references()`에 `query_vector` 파라미터 추가 — pre-computed 벡터 전달 시 embed() 호출 생략
- 임베딩 배치 실패 시 per-clause 폴백 유지 (안전)

## 효과
- 인제스션: 헤더 패턴이 명확한 계약서(한국어 표준형식)는 즉시 regex로 처리
- 분석: N조항 문서 기준 embed() 호출 N번 → 1번

Closes #62