### PR TITLE
fix(#66): RAG 판례 검색 쿼리를 LLM issue_types+summary 기반으로 교체

### DIFF
--- a/app/services/rag.py
+++ b/app/services/rag.py
@@ -50,16 +50,13 @@ async def search_legal_references(
     query_text: str,
     top_k: int = 3,
     ref_type: str | None = None,
-    query_vector: list[float] | None = None,
 ) -> list[dict[str, Any]]:
     """Search Qdrant cases collection for relevant 판례/법령.
 
     Args:
-        query_text: clause text to search against.
+        query_text: focused search query (LLM issue labels + summary recommended).
         top_k: number of results to return.
         ref_type: optional filter — "prec" for 판례, "law" for 법령, None for both.
-        query_vector: pre-computed embedding vector. When provided, the embed()
-            call is skipped, saving one API round-trip.
     """
     client = _get_client()
 
@@ -68,9 +65,8 @@ async def search_legal_references(
     if CASES_COLLECTION_NAME not in existing:
         return []
 
-    if query_vector is None:
-        vectors = await embed([query_text])
-        query_vector = vectors[0]
+    vectors = await embed([query_text])
+    query_vector = vectors[0]
 
     must: list[Any] = []
     if ref_type:

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -44,7 +44,6 @@ from app.db import (
 )
 from app.errors import PermanentError, RetryableError
 from app.services import rag as rag_svc
-from app.services.embeddings import embed
 from app.services.llm import (
     MODEL,
     ClauseAnalysisResult,
@@ -141,18 +140,29 @@ def _classify_exception(exc: BaseException) -> type[RetryableError | PermanentEr
     return RetryableError
 
 
+def _build_rag_query(llm_result: ClauseAnalysisResult) -> str:
+    """Build a focused RAG search query from LLM analysis results.
+
+    Using the full clause text (up to 3000 chars) as a query dilutes the
+    embedding with irrelevant boilerplate.  The LLM has already extracted
+    the legally-relevant issues; search those directly for much better recall.
+    """
+    parts: list[str] = []
+    if llm_result.issue_types:
+        labels = [_ISSUE_LABELS.get(it, it) for it in llm_result.issue_types]
+        parts.append(" ".join(labels))
+    if llm_result.summary:
+        parts.append(llm_result.summary)
+    return " ".join(parts) if parts else "계약 조항"
+
+
 async def _analyze_single_clause(
     pool: asyncpg.Pool,
     analysis_id: str,
     clause: asyncpg.Record,
     semaphore: asyncio.Semaphore,
-    clause_vector: list[float] | None = None,
 ) -> ClauseAnalysisResult:
-    """Run LLM + RAG for one clause, persist results, and return the LLM result.
-
-    clause_vector: pre-computed embedding for this clause.  When provided, the
-        RAG step skips the embed() call, saving one API round-trip per clause.
-    """
+    """Run LLM analysis then RAG for one clause, persist results, and return the LLM result."""
     async with semaphore:
         clause_id: str = clause["id"]
         clause_text: str = clause["content"]
@@ -182,12 +192,13 @@ async def _analyze_single_clause(
             )
             raise
 
-        # RAG: 판례/법령만 증거로 사용.
-        # Pass pre-computed vector to skip the per-clause embed() round-trip.
+        # RAG: LLM 분석 결과(issue_types + summary)를 검색 쿼리로 사용.
+        # 조항 원문 전체를 임베딩하면 법적 핵심이 희석되므로,
+        # LLM이 추출한 이슈 키워드 + 요약을 쿼리로 사용해 정확도를 높인다.
+        rag_query = _build_rag_query(llm_result)
         legal_refs = await rag_svc.search_legal_references(
-            query_text=clause_text,
+            query_text=rag_query,
             top_k=5,
-            query_vector=clause_vector,
         )
 
         citations = [
@@ -307,26 +318,12 @@ async def _process(pool: asyncpg.Pool, msg: dict[str, Any]) -> None:
 
     log.info("loaded clauses", count=len(clauses))
 
-    # Pre-batch embed all clause texts in a single API call.
-    # Each clause would otherwise embed individually inside search_legal_references,
-    # resulting in N serial round-trips.  One batch call reduces this to O(1).
-    clause_texts = [c["content"] for c in clauses]
-    try:
-        clause_vectors: list[list[float] | None] = await embed(clause_texts)
-        log.info("batch embedding complete", clause_count=len(clause_vectors))
-    except Exception as exc:
-        log.warning(
-            "batch embedding failed — RAG will embed per-clause",
-            error=str(exc),
-        )
-        clause_vectors = [None] * len(clauses)
-
     # Step 3 — parallel analysis with bounded concurrency.
     # Use return_exceptions=True so a single clause failure does not abort others.
     semaphore = asyncio.Semaphore(_MAX_CONCURRENCY)
     tasks = [
-        _analyze_single_clause(pool, analysis_id, clause, semaphore, vec)
-        for clause, vec in zip(clauses, clause_vectors)
+        _analyze_single_clause(pool, analysis_id, clause, semaphore)
+        for clause in clauses
     ]
     results = await asyncio.gather(*tasks, return_exceptions=True)
 


### PR DESCRIPTION
## 문제
조항 원문 전체(최대 3000자)를 RAG 쿼리로 사용하면:
- 임베딩이 계약서 보일러플레이트까지 평균화
- 법적 핵심 이슈 신호가 희석
- 판례/법령 검색 정확도 저하

LLM이 이미 `issue_types`와 `summary`를 추출해 놓았는데 활용하지 않던 문제.

## 변경사항
- `_build_rag_query()` 추가: `issue_types` 한국어 레이블 + `summary` 조합 → 집중된 검색 쿼리
- RAG 호출 위치를 LLM 분석 **후**로 유지 (결과 활용)
- 분석 전 조항 배치 임베딩 코드 제거 (불필요한 API 호출 제거)
- `rag.search_legal_references()`에서 `query_vector` 파라미터 제거

## 검색 쿼리 예시
before: `"갑은 어떠한 경우에도 을에게 손해배상 책임을 지지 않는다..."` (원문 3000자)
after: `"손해배상 제한 면책 계약상 손해배상 한도가 없거나 지나치게 제한됩니다"` (집중 키워드)

Closes #66