### PR TITLE
fix(#68): 짧은 조항(제1조, 제4조) 누락 버그 수정 — MIN_CLAUSE_LEN 30→5

### DIFF
--- a/app/services/parser.py
+++ b/app/services/parser.py
@@ -66,7 +66,9 @@ _KO_HEADER = re.compile(
     re.IGNORECASE,
 )
 
-_MIN_CLAUSE_LEN = 30
+# 최소 길이는 페이지 번호·공백 같은 노이즈만 걸러낼 수 있을 만큼 낮게 유지한다.
+# 30자로 설정하면 짧은 정상 조항(예: "제1조\n계약 당사자는 갑·을이다.")도 드롭됨.
+_MIN_CLAUSE_LEN = 5
 _MAX_CLAUSE_LEN = 3000
 
 # ---------------------------------------------------------------------------
@@ -132,7 +134,12 @@ def _flush_lines(
 ) -> int:
     """Merge lines into Clause(s), appending to out. Returns updated char_offset."""
     merged = "\n".join(lines).strip()
-    if len(merged) < _MIN_CLAUSE_LEN:
+    # 헤더 패턴으로 시작하는 조항은 길이 무관하게 보존한다.
+    # 짧아도 정상 조항(예: "제4조\n기간: 미정")이 누락되는 것을 방지.
+    has_header = (
+        bool(_KO_HEADER.match(merged.split("\n")[0].strip())) if merged else False
+    )
+    if len(merged) < _MIN_CLAUSE_LEN and not has_header:
         return char_offset
 
     if len(merged) > _MAX_CLAUSE_LEN:


### PR DESCRIPTION
## 문제
`_MIN_CLAUSE_LEN=30` 필터가 본문이 짧은 조항을 드롭함.
나쁜_계약서.pdf에서 제1조, 제4조 누락 확인 (28개 단락 → 8개 조항, 10개 예상).

## 변경사항
- `_MIN_CLAUSE_LEN`: 30 → 5 (페이지번호·공백 노이즈만 걸러냄)
- `_flush_lines()`: `_KO_HEADER` 패턴으로 시작하는 조항은 길이 무관 보존

Closes #68