### PR TITLE
feat(#74): RAG-Augmented LLM — 판례/법령을 LLM 프롬프트에 주입

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -46,14 +46,14 @@ def _is_retryable(exc: BaseException) -> bool:
 _ANALYSIS_PROMPT_TEMPLATE = """계약서 조항을 분석하여 리스크를 평가해주세요.
 
 조항: {clause_text}
-
+{legal_context_section}
 다음 JSON 형식으로만 응답하세요:
 {{
   "risk_level": "HIGH|MEDIUM|LOW",
   "confidence": 0.85,
   "issue_types": ["LIABILITY_LIMITATION", ...],
   "summary": "한국어 리스크 요약 (2-3문장)",
-  "rationale": "판단 근거 상세 설명"
+  "rationale": "판단 근거 상세 설명 — 관련 판례/법령이 제공된 경우 이를 구체적으로 인용할 것"
 }}
 
 confidence 필드 설명:
@@ -71,6 +71,26 @@ confidence 필드 설명:
 - CONFIDENTIALITY: 기밀유지
 - INDEMNITY: 면책 조항
 - PAYMENT_TERMS: 지급 조건"""
+
+
+def _build_legal_context_section(legal_refs: list[dict]) -> str:
+    """Format retrieved 판례/법령 as a prompt section for the LLM."""
+    if not legal_refs:
+        return ""
+    lines = ["\n관련 판례/법령 (분석 시 참고하여 rationale에 인용):"]
+    for i, ref in enumerate(legal_refs[:3], 1):  # 최대 3개만 주입
+        ref_type = "판례" if ref.get("type") == "prec" else "법령"
+        title = ref.get("title", "")
+        content = ref.get("content", "")[:300].replace("\n", " ")
+        date = ref.get("date", "")
+        court = ref.get("court", "")
+        meta = f"{court} {date}".strip() if (court or date) else ""
+        lines.append(
+            f"[{i}] [{ref_type}] {title}"
+            + (f" ({meta})" if meta else "")
+            + f"\n    {content}"
+        )
+    return "\n".join(lines) + "\n"
 
 
 @dataclass
@@ -389,10 +409,24 @@ async def extract_clause_boundaries(
     return unique
 
 
-async def analyze_clause(clause_text: str) -> ClauseAnalysisResult:
-    """Run LLM risk analysis on a single clause and return structured result."""
+async def analyze_clause(
+    clause_text: str,
+    legal_refs: list[dict] | None = None,
+) -> ClauseAnalysisResult:
+    """Run LLM risk analysis on a single clause and return structured result.
+
+    Args:
+        clause_text: the raw clause to analyze.
+        legal_refs: optional list of retrieved 판례/법령 from RAG search.
+            When provided, injected into the prompt so the LLM can cite them
+            in the rationale instead of reasoning from scratch.
+    """
     client = _get_client()
-    prompt = _ANALYSIS_PROMPT_TEMPLATE.format(clause_text=clause_text)
+    legal_context_section = _build_legal_context_section(legal_refs or [])
+    prompt = _ANALYSIS_PROMPT_TEMPLATE.format(
+        clause_text=clause_text,
+        legal_context_section=legal_context_section,
+    )
 
     try:
         raw_text = await _call_llm(client, prompt)

--- a/app/workers/analysis.py
+++ b/app/workers/analysis.py
@@ -140,37 +140,6 @@ def _classify_exception(exc: BaseException) -> type[RetryableError | PermanentEr
     return RetryableError
 
 
-# issue_type → 판례/법령에 실제로 등장하는 법률 용어 (임베딩 유사도 극대화)
-_ISSUE_LEGAL_TERMS: dict[str, str] = {
-    "LIABILITY_LIMITATION": "손해배상 책임 제한 한도 약관 불공정",
-    "TERMINATION_RIGHT": "계약해지 일방적 해지권 해지 요건 통보",
-    "IP_OWNERSHIP": "저작권 특허권 귀속 직무발명 양도 영업비밀 침해",
-    "PENALTY_CLAUSE": "위약금 손해배상예정액 위약벌 과다 감액 불공정",
-    "FORCE_MAJEURE": "불가항력 면책 이행불능 천재지변",
-    "GOVERNING_LAW": "준거법 관할 국제사법 재판 합의",
-    "CONFIDENTIALITY": "영업비밀 비밀유지 경업금지 기밀 누설 금지",
-    "INDEMNITY": "면책 손해배상 책임 배상 제한 약관",
-    "PAYMENT_TERMS": "하도급 대금 지급 연체 지체상금 약관 불공정",
-}
-
-
-def _build_rag_query(llm_result: ClauseAnalysisResult) -> str:
-    """Build a focused RAG search query from LLM analysis results.
-
-    Uses issue_type → legal terminology mapping rather than the LLM summary
-    text, because actual 판례/법령 use specific legal vocabulary (e.g.
-    '손해배상예정액 감액', '경업금지 약정 유효성') that does not appear in
-    plain-language summaries.  Mixing the summary adds noise and degrades
-    cosine similarity scores.
-    """
-    parts: list[str] = []
-    for it in llm_result.issue_types:
-        legal_terms = _ISSUE_LEGAL_TERMS.get(it)
-        if legal_terms:
-            parts.append(legal_terms)
-    return " ".join(parts) if parts else "계약 조항"
-
-
 async def _analyze_single_clause(
     pool: asyncpg.Pool,
     analysis_id: str,
@@ -190,13 +159,28 @@ async def _analyze_single_clause(
 
         log.info("analyzing clause", clause_id=clause_id, label=label)
 
-        # LLM analysis with per-clause total timeout.
+        # Step 1: RAG 먼저 — 조항 앞부분(헤더+첫 문장)으로 관련 판례/법령 검색.
+        # 전체 조항 텍스트 대신 앞 300자를 사용해 핵심 주제가 임베딩에 집중되도록 함.
+        # 검색 결과는 LLM 프롬프트에 주입되어 AI가 실제 판례 근거로 분석하게 함.
+        rag_query_text = clause_text[:300]
+        legal_refs = await rag_svc.search_legal_references(
+            query_text=rag_query_text,
+            top_k=5,
+        )
+        log.info(
+            "rag pre-fetch complete",
+            clause_id=clause_id,
+            refs_found=len(legal_refs),
+        )
+
+        # Step 2: LLM 분석 — RAG 결과를 컨텍스트로 주입.
         # analyze_clause() already applies a 60 s call-level timeout; this outer
-        # guard covers the full pipeline (LLM + RAG + DB) to prevent a semaphore
+        # guard covers the full pipeline (RAG + LLM + DB) to prevent a semaphore
         # slot from being occupied indefinitely.
         try:
             llm_result = await asyncio.wait_for(
-                analyze_clause(clause_text), timeout=_CLAUSE_TIMEOUT
+                analyze_clause(clause_text, legal_refs=legal_refs),
+                timeout=_CLAUSE_TIMEOUT,
             )
         except TimeoutError:
             log.error(
@@ -206,15 +190,6 @@ async def _analyze_single_clause(
                 timeout=_CLAUSE_TIMEOUT,
             )
             raise
-
-        # RAG: LLM 분석 결과(issue_types + summary)를 검색 쿼리로 사용.
-        # 조항 원문 전체를 임베딩하면 법적 핵심이 희석되므로,
-        # LLM이 추출한 이슈 키워드 + 요약을 쿼리로 사용해 정확도를 높인다.
-        rag_query = _build_rag_query(llm_result)
-        legal_refs = await rag_svc.search_legal_references(
-            query_text=rag_query,
-            top_k=5,
-        )
 
         citations = [
             {


### PR DESCRIPTION
## 변경사항
### 기존 구조 (잘못됨)
```
LLM 분석 → RAG 검색 → 판례 그냥 저장 (LLM이 판례 안 봄)
```

### 변경 후 구조 (올바른 RAG)
```
RAG 검색 (조항 앞 300자) → LLM 분석 + 판례 컨텍스트 주입 → rationale에 판례 인용
```

### 파일별 변경
- **llm.py**: `analyze_clause(legal_refs=None)` 파라미터 추가. `_build_legal_context_section()`으로 상위 3개 판례/법령 포맷 후 프롬프트에 주입
- **analysis.py**: RAG → LLM 순서로 변경. 미사용 `_build_rag_query` / `_ISSUE_LEGAL_TERMS` 제거

Closes #74